### PR TITLE
Replace deb dependency 'openjdk-8-jre' with 'openjdk-7-jre'.

### DIFF
--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -62,5 +62,4 @@ ospackage {
 
 buildDeb {
   dependsOn installApp
-  requires("openjdk-7-jre")
 }


### PR DESCRIPTION
This matches mayo's buildDeb setup.
Tested:
- ./gradlew clean buildDeb
- Copied generated .deb to fresh vm.
- sudo apt-get installed redis-server.
- dpkg -i installed rosco .deb.
- /opt/rosco/bin/rosco &
- curl localhost:8087

@ewiseblatt please review.
