### PR TITLE
Swap the order of commit and build number in generated appversion tags.

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
@@ -118,15 +118,15 @@ class PackageNameConverter {
       if (version) {
         appVersion += "-$version"
 
-        if (commit) {
-          appVersion += "-$commit"
+        if (bakeRequest.build_number) {
+          appVersion += "-h$bakeRequest.build_number"
 
-          if (buildNumber) {
-            appVersion += ".$buildNumber"
+          if (commit) {
+            appVersion += ".$commit"
+          }
 
-            if (bakeRequest.job && bakeRequest.build_number) {
-              appVersion += "/$bakeRequest.job/$bakeRequest.build_number"
-            }
+          if (bakeRequest.job && bakeRequest.build_number) {
+            appVersion += "/$bakeRequest.job/$bakeRequest.build_number"
           }
         }
       }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactorySpec.groovy
@@ -28,6 +28,7 @@ class DefaultImageNameFactorySpec extends Specification {
       def clockMock = Mock(Clock)
       def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
       def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced_0.1-h12.170cdbd_all",
+                                        build_number: "12",
                                         base_os: BakeRequest.OperatingSystem.ubuntu)
 
     when:
@@ -36,7 +37,7 @@ class DefaultImageNameFactorySpec extends Specification {
     then:
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-ubuntu"
-      appVersionStr == "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced"
   }
 
@@ -62,6 +63,7 @@ class DefaultImageNameFactorySpec extends Specification {
       def clockMock = Mock(Clock)
       def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
       def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced_0.1-h12.170cdbd_all kato redis-server",
+                                        build_number: "12",
                                         base_os: BakeRequest.OperatingSystem.ubuntu)
 
     when:
@@ -70,7 +72,7 @@ class DefaultImageNameFactorySpec extends Specification {
     then:
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-ubuntu"
-      appVersionStr == "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced kato redis-server"
   }
 
@@ -79,6 +81,7 @@ class DefaultImageNameFactorySpec extends Specification {
       def clockMock = Mock(Clock)
       def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
       def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced_0.1-h12.170cdbd_all some-package_0.3-h15.290fcab_all",
+                                        build_number: "12",
                                         base_os: BakeRequest.OperatingSystem.ubuntu)
 
     when:
@@ -87,7 +90,7 @@ class DefaultImageNameFactorySpec extends Specification {
     then:
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-ubuntu"
-      appVersionStr == "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced some-package_0.3-h15.290fcab_all"
   }
 
@@ -96,6 +99,7 @@ class DefaultImageNameFactorySpec extends Specification {
       def clockMock = Mock(Clock)
       def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
       def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced-0.1-h12.170cdbd-all",
+                                        build_number: "12",
                                         base_os: BakeRequest.OperatingSystem.centos)
 
     when:
@@ -104,7 +108,7 @@ class DefaultImageNameFactorySpec extends Specification {
     then:
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-centos"
-      appVersionStr == "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced"
   }
 
@@ -113,6 +117,7 @@ class DefaultImageNameFactorySpec extends Specification {
       def clockMock = Mock(Clock)
       def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
       def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced-0.1-h12.170cdbd-all kato redis-server",
+                                        build_number: "12",
                                         base_os: BakeRequest.OperatingSystem.centos)
 
     when:
@@ -121,7 +126,7 @@ class DefaultImageNameFactorySpec extends Specification {
     then:
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-centos"
-      appVersionStr == "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced kato redis-server"
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
@@ -79,15 +79,15 @@ class PackageNameConverterSpec extends Specification {
     setup:
       def debPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
       def rpmPackageName = "nflx-djangobase-enhanced-0.1-h12.170cdbd-all"
-      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-h12.170cdbd"
 
     when:
       def parsedDebPackageName = PackageNameConverter.parseDebPackageName(debPackageName)
       def parsedRpmPackageName = PackageNameConverter.parseRpmPackageName(rpmPackageName)
       def appVersionStrFromDebPackageName =
-        PackageNameConverter.buildAppVersionStr(new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu), debPackageName)
+        PackageNameConverter.buildAppVersionStr(new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu, build_number: "12"), debPackageName)
       def appVersionStrFromRpmPackageName =
-        PackageNameConverter.buildAppVersionStr(new BakeRequest(base_os: BakeRequest.OperatingSystem.centos), rpmPackageName)
+        PackageNameConverter.buildAppVersionStr(new BakeRequest(base_os: BakeRequest.OperatingSystem.centos, build_number: "12"), rpmPackageName)
 
     then:
       parsedDebPackageName == parsedRpmPackageName
@@ -97,8 +97,8 @@ class PackageNameConverterSpec extends Specification {
 
   void "if job and build_number are specified, app version string includes them"() {
     setup:
-      def debPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
-      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12/some-job-name/123"
+      def debPackageName = "nflx-djangobase-enhanced_0.1-h123.170cdbd_all"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-h123.170cdbd/some-job-name/123"
       def bakeRequest = new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu,
                                         job: "some-job-name",
                                         build_number: "123")
@@ -110,21 +110,14 @@ class PackageNameConverterSpec extends Specification {
       appVersionStrFromDebPackageName == appVersionStr
   }
 
-  void "if either job or build_number are missing, app version string leaves off both job and build_number"() {
+  void "if job is missing, app version string leaves off both job and build_number"() {
     setup:
       def debPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
-      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-h12.170cdbd"
 
     when:
-      def bakeRequest = new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu, job: "some-job-name")
+      def bakeRequest = new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu, build_number: "12")
       def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, debPackageName)
-
-    then:
-      appVersionStrFromDebPackageName == appVersionStr
-
-    when:
-      bakeRequest = new BakeRequest(base_os: BakeRequest.OperatingSystem.ubuntu, build_number: "123")
-      appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, debPackageName)
 
     then:
       appVersionStrFromDebPackageName == appVersionStr


### PR DESCRIPTION
Make commit optional w.r.t. determining whether an appversion tag is generated (as AppVersion.parseName() itself treats this as optional).
Use BakeRequest.build_number in appversion tag instead of the build number parsed out of the release segment of the package name.
@ewiseblatt please review.
