### PR TITLE
Make the deb_repo parameter to both GCE and AWS packer templates opti…

### DIFF
--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -11,7 +11,7 @@
     "aws_target_ami": null,
     "appversion": "",
     "build_host": "",
-    "deb_repo": null,
+    "deb_repo": "",
     "packages": "",
     "configDir": null
   },

--- a/rosco-web/config/packer/gce.json
+++ b/rosco-web/config/packer/gce.json
@@ -7,7 +7,7 @@
     "gce_target_image": null,
     "appversion": "",
     "build_host": "",
-    "deb_repo": null,
+    "deb_repo": "",
     "packages": "",
     "configDir": null
   },

--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -10,6 +10,10 @@ deb_repo=`echo $deb_repo | sed 's/^"\(.*\)"$/\1/'`
 # Strip leading/trailing quotes if present.
 packages=`echo $packages | sed 's/^"\(.*\)"$/\1/'`
 
-echo "deb $deb_repo" | sudo tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
+# Only add the new source repository if deb_repo is set.
+if [[ "$deb_repo" != "" ]]; then
+  echo "deb $deb_repo" | sudo tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
+fi
+
 sudo apt-get update
 sudo apt-get install --force-yes -y $packages

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -28,7 +28,10 @@ executionStatusToBakeResults:
     - executionStatus: FAILED
       bakeResult: FAILURE
 
-debianRepository: http://dl.bintray.com/spinnaker/ospackages ./
+# If a repository is set here, it will be added by packer as an apt repository when baking images for GCE and AWS.
+# It is safe to leave this out (or blank) if you do not need to configure your own apt repository.
+# The following commented-out line is an example of what a valid entry looks like.
+# debianRepository: http://dl.bintray.com/spinnaker/ospackages ./
 
 defaultCloudProviderType: aws
 


### PR DESCRIPTION
…onal.

Make install_packages.sh script tolerant of missing deb_repo.
Comment-out debianRepository attribute from checked-in rosco.yml, but leave it with some comments as an example.

Tested:
  Amazon bake with package from specified deb_repo.
  Amazon bake with redis-server and no deb_repo specified.
  Google bake with package from specified deb_repo.
  Google bake with redis-server and no deb_repo specified.