### PR TITLE
removed aws os: ubuntu definitions from rosco.yml. name "ubuntu" is a…

### DIFF
--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -45,29 +45,6 @@ aws:
     # TODO(duftler): Support additional store types beyond ebs.
     # TODO(duftler): Support additional operating systems.
     # TODO(duftler): Feels like just about everything here could be (optionally) specified per bake.
-    - os: ubuntu
-      virtualizationSettings:
-      - region: us-east-1
-        virtualizationType: hvm
-        instanceType: t2.micro
-        sourceAmi: ami-d4aed0bc
-        sshUserName: ubuntu
-      - region: us-west-2
-        virtualizationType: hvm
-        instanceType: t2.micro
-        sourceAmi: ami-59396769
-        sshUserName: ubuntu
-      - region: us-east-1
-        virtualizationType: pv
-        instanceType: m3.medium
-        sourceAmi: ami-8007b2e8
-        sshUserName: ubuntu
-#      No exact equivalent available in us-west-2
-#      - region: us-west-2
-#        virtualizationType: pv
-#        instanceType: m3.medium
-#        sourceAmi: 
-#        sshUserName: ubuntu
     - os: trusty
       virtualizationSettings:
       - region: us-east-1


### PR DESCRIPTION
…mbiguous and amis were for 12.04

This is a fix for https://github.com/spinnaker/spinnaker/issues/597
