### PR TITLE
Set initial interval of rush health ping to 5 minutes.

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/rush/health/RushHealthIndicator.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/rush/health/RushHealthIndicator.groovy
@@ -52,7 +52,7 @@ class RushHealthIndicator implements HealthIndicator {
     new Health.Builder().up().build()
   }
 
-  @Scheduled(fixedDelay = 300000L)
+  @Scheduled(initialDelay = 300000L, fixedDelay = 300000L)
   void checkHealth() {
     try {
       // TODO(duftler): Use less-expensive health check.


### PR DESCRIPTION
Will help avoid the initial stack-trace when rush and rosco are starting up at the same time.
@spinnaker/google-reviewers please review.