### PR TITLE
Scope incomplete bakes to specific Rosco instance.

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
@@ -45,6 +45,11 @@ import java.time.Clock
 class RoscoConfiguration {
 
   @Bean
+  String roscoInstanceId() {
+    UUID.randomUUID().toString()
+  }
+
+  @Bean
   @ConditionalOnMissingBean(BakePoller)
   BakePoller bakePoller() {
     new BakePoller()


### PR DESCRIPTION
With this change, each Rosco instance will only query for status updates for its own incomplete bakes.