### PR TITLE
When rosco fails to retrieve job status from rush for an incomplete b…

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
@@ -111,10 +111,7 @@ class BakePoller implements ApplicationListener<ContextRefreshedEvent> {
     } catch (RetrofitError e) {
       handleRetrofitError(e, "Unable to retrieve status for '$statusId'.", statusId)
 
-      bakeStore.updateBakeStatus(new BakeStatus(id: statusId,
-                                                resource_id: statusId,
-                                                state: BakeStatus.State.CANCELED,
-                                                result: BakeStatus.Result.FAILURE))
+      bakeStore.cancelBakeById(statusId)
     }
   }
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -163,10 +163,7 @@ class BakePollerSpec extends Specification {
 
       1 * rushServiceMock.scriptDetails(SCRIPT_ID) >> { throw retrofitError }
       1 * bakeStoreMock.storeBakeError(SCRIPT_ID, "\"Some Rush error...\"")
-      1 * bakeStoreMock.updateBakeStatus(new BakeStatus(id: SCRIPT_ID,
-                                                        resource_id: SCRIPT_ID,
-                                                        state: BakeStatus.State.CANCELED,
-                                                        result: BakeStatus.Result.FAILURE))
+      1 * bakeStoreMock.cancelBakeById(SCRIPT_ID)
   }
 
 }


### PR DESCRIPTION
…ake, and deems the bake to have failed, save the logs.

This behavior now matches that of the /cancel entry-point.

@ttomsu please review.