### PR TITLE
Add support for optional templateFileName and extendedAttributes on B…

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -45,14 +45,21 @@ class BakeRequest {
   @ApiModelProperty("The target platform")
   CloudProviderType cloud_provider_type
   Label base_label
+  @ApiModelProperty("The named base image to resolve from rosco's configuration")
   String base_os
   String base_name
+  @ApiModelProperty("The explicit machine image to use, instead of resolving one from rosco's configuration")
   String base_ami
   VmType vm_type
   StoreType store_type
   Boolean enhanced_networking
   String ami_name
   String ami_suffix
+
+  @ApiModelProperty("The explicit packer template to use, instead of resolving one from rosco's configuration")
+  String template_file_name
+  @ApiModelProperty("A map of key/value pairs to add to the packer command")
+  Map extended_attributes
 
   static enum CloudProviderType {
     aws, docker, gce

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -120,7 +120,13 @@ abstract class CloudProviderBakeHandler {
 
     parameterMap.configDir = configDir
 
-    return packerCommandFactory.buildPackerCommand(baseCommand, parameterMap, "$configDir/$templateFileName")
+    if (bakeRequest.extended_attributes) {
+      parameterMap << bakeRequest.extended_attributes
+    }
+
+    def finalTemplateFileName = bakeRequest.template_file_name ?: templateFileName
+
+    return packerCommandFactory.buildPackerCommand(baseCommand, parameterMap, "$configDir/$finalTemplateFileName")
   }
 
   BaseImage findBaseImage(BakeRequest bakeRequest) {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -294,6 +294,86 @@ class AWSBakeHandlerSpec extends Specification {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
+  void 'produces packer command with all required parameters for ubuntu, using explicit vm type, and overriding template filename'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGE_NAME,
+                                        base_os: "ubuntu",
+                                        vm_type: BakeRequest.VmType.pv,
+                                        cloud_provider_type: BakeRequest.CloudProviderType.aws,
+                                        template_file_name: "somePackerTemplate.json")
+      def targetImageName = "kato-x8664-timestamp-ubuntu"
+      def parameterMap = [
+        aws_access_key: awsBakeryDefaults.awsAccessKey,
+        aws_secret_key: awsBakeryDefaults.awsSecretKey,
+        aws_region: REGION,
+        aws_ssh_username: "ubuntu",
+        aws_instance_type: "m3.medium",
+        aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
+        aws_target_ami: targetImageName,
+        deb_repo: DEBIAN_REPOSITORY,
+        packages: PACKAGE_NAME,
+        configDir: configDir
+      ]
+
+      @Subject
+      AWSBakeHandler awsBakeHandler = new AWSBakeHandler(configDir: configDir,
+                                                         awsBakeryDefaults: awsBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/somePackerTemplate.json")
+  }
+
+  void 'produces packer command with all required parameters for ubuntu, using explicit vm type, and adding extended attributes'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGE_NAME,
+                                        base_os: "ubuntu",
+                                        vm_type: BakeRequest.VmType.pv,
+                                        cloud_provider_type: BakeRequest.CloudProviderType.aws,
+                                        extended_attributes: [someAttr1: "someValue1", someAttr2: "someValue2"])
+      def targetImageName = "kato-x8664-timestamp-ubuntu"
+      def parameterMap = [
+        aws_access_key: awsBakeryDefaults.awsAccessKey,
+        aws_secret_key: awsBakeryDefaults.awsSecretKey,
+        aws_region: REGION,
+        aws_ssh_username: "ubuntu",
+        aws_instance_type: "m3.medium",
+        aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
+        aws_target_ami: targetImageName,
+        deb_repo: DEBIAN_REPOSITORY,
+        packages: PACKAGE_NAME,
+        configDir: configDir,
+        someAttr1: "someValue1",
+        someAttr2: "someValue2"
+      ]
+
+      @Subject
+      AWSBakeHandler awsBakeHandler = new AWSBakeHandler(configDir: configDir,
+                                                         awsBakeryDefaults: awsBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
+  }
+
   void 'produces packer command with all required parameters for trusty, using explicit vm type'() {
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -210,6 +210,80 @@ class GCEBakeHandlerSpec extends Specification {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
+  void 'produces packer command with all required parameters for ubuntu, and overriding template filename'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGE_NAME,
+                                        base_os: "ubuntu",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        template_file_name: "somePackerTemplate.json")
+      def targetImageName = "kato-x8664-timestamp-ubuntu"
+      def parameterMap = [
+        gce_project_id: googleConfigurationProperties.accounts.get(0).project,
+        gce_zone: gceBakeryDefaults.zone,
+        gce_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        gce_target_image: targetImageName,
+        deb_repo: DEBIAN_REPOSITORY,
+        packages: PACKAGE_NAME,
+        configDir: configDir
+      ]
+
+      @Subject
+      GCEBakeHandler gceBakeHandler = new GCEBakeHandler(configDir: configDir,
+                                                         gceBakeryDefaults: gceBakeryDefaults,
+                                                         googleConfigurationProperties: googleConfigurationProperties,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/somePackerTemplate.json")
+  }
+
+  void 'produces packer command with all required parameters for ubuntu, and adding extended attributes'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGE_NAME,
+                                        base_os: "ubuntu",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        extended_attributes: [someAttr1: "someValue1", someAttr2: "someValue2"])
+      def targetImageName = "kato-x8664-timestamp-ubuntu"
+      def parameterMap = [
+        gce_project_id: googleConfigurationProperties.accounts.get(0).project,
+        gce_zone: gceBakeryDefaults.zone,
+        gce_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        gce_target_image: targetImageName,
+        deb_repo: DEBIAN_REPOSITORY,
+        packages: PACKAGE_NAME,
+        configDir: configDir,
+        someAttr1: "someValue1",
+        someAttr2: "someValue2"
+      ]
+
+      @Subject
+      GCEBakeHandler gceBakeHandler = new GCEBakeHandler(configDir: configDir,
+                                                         gceBakeryDefaults: gceBakeryDefaults,
+                                                         googleConfigurationProperties: googleConfigurationProperties,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
+  }
+
   void 'produces packer command with all required parameters for trusty'() {
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)


### PR DESCRIPTION
…akeRequest.

templateFileName will override the packer template(s) configured in rosco.yml, and extendedAttributes will be added as key/value pairs to the packer command.