### PR TITLE
Fail the build if there is an error installing packages

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Make rush fail the build on errors.
+set -e
+
 # Strip the first part to avoid credentials leaks.
 echo "repository=$(echo $repository | sed s/^.*@//g)"
 echo "package_type=$package_type"


### PR DESCRIPTION
We have seen failing package installs with amazon linux reported as successful bakes.

This makes the install packages script fail on errors.