### PR TITLE
Dont start services when installing packages on debian based machines

### DIFF
--- a/rosco-web/config/packer/aws-chroot.json
+++ b/rosco-web/config/packer/aws-chroot.json
@@ -35,7 +35,8 @@
       "repository={{user `repository`}}",
       "package_type={{user `package_type`}}",
       "packages={{user `packages`}}",
-      "upgrade={{user `upgrade`}}"
+      "upgrade={{user `upgrade`}}",
+      "disable_services=true"
     ]
   }]
 }


### PR DESCRIPTION
When services are started on install, sometimes the bake fails because its unable to umount the disk:
` Stderr: umount: /mnt/packer-amazon-chroot-volumes/xvdg/dev: device is busy.`

https://www.packer.io/docs/builders/amazon-chroot.html look at gotchas at the end.

The reason this is done in install_packages.sh and not in the template is because of support for non debian based distros.