### PR TITLE
Use sudo when running aws-chroot builder

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
@@ -36,6 +36,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
+import org.springframework.core.convert.ConversionService
+import org.springframework.core.convert.support.DefaultConversionService
 import redis.clients.jedis.JedisPool
 
 import java.time.Clock
@@ -63,6 +65,12 @@ class RoscoConfiguration {
   @Bean
   CloudProviderBakeHandlerRegistry cloudProviderBakeHandlerRegistry() {
     return new DefaultCloudProviderBakeHandlerRegistry()
+  }
+
+  // Allows @Value annotation to tokenize a list of strings.
+  @Bean
+  ConversionService conversionService() {
+    return new DefaultConversionService()
   }
 
   @Bean

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -42,6 +42,9 @@ abstract class CloudProviderBakeHandler {
   @Value('${yumRepository:}')
   String yumRepository
 
+  @Value('${templatesNeedingRoot:}')
+  List<String> templatesNeedingRoot
+
   /**
    * @return A cloud provider-specific set of defaults.
    */
@@ -120,7 +123,11 @@ abstract class CloudProviderBakeHandler {
    * Returns the command that should be prepended to the shell command passed to the container.
    */
   String getBaseCommand() {
-    return ""
+    if (templatesNeedingRoot) {
+      return templatesNeedingRoot.contains(getBakeryDefaults().templateFile) ? "sudo" : ""
+    } else {
+      return ""
+    }
   }
 
   /**

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
@@ -20,8 +20,7 @@ class LocalJobFriendlyPackerCommandFactory implements PackerCommandFactory {
 
   @Override
   List<String> buildPackerCommand(String baseCommand, Map<String, String> parameterMap, String absoluteTemplateFilePath) {
-    def packerCommand = ["packer", "build", "-color=false"]
-
+    def packerCommand = [baseCommand, "packer", "build", "-color=false"]
     parameterMap.each { key, value ->
       if (key && value) {
         def keyValuePair = value instanceof String && value.contains(" ") ? "$key=\"$value\"" : "$key=$value"
@@ -32,6 +31,7 @@ class LocalJobFriendlyPackerCommandFactory implements PackerCommandFactory {
     }
 
     packerCommand << absoluteTemplateFilePath
+    packerCommand.removeAll([null, ""])
 
     packerCommand
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.rosco.providers.util
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class LocalJobFriendlyPackerCommandFactorySpec extends Specification {
+
+  @Shared
+  LocalJobFriendlyPackerCommandFactory packerCommandFactory = new LocalJobFriendlyPackerCommandFactory()
+
+  void "packerCommand handles baseCommand as null, empty string and real string"() {
+    setup:
+    def parameterMap = [
+      something:   something
+    ]
+
+    when:
+    def packerCommand = packerCommandFactory.buildPackerCommand(baseCommand, parameterMap, "")
+
+    then:
+    packerCommand == expectedPackerCommand
+
+    where:
+    something | baseCommand | expectedPackerCommand
+    "sudo"    | "sudo"      | ["sudo", "packer", "build", "-color=false", "-var", "something=sudo"]
+    "null"    | null        | ["packer", "build", "-color=false", "-var", "something=null"]
+    "empty"   | ""          | ["packer", "build", "-color=false", "-var", "something=empty"]
+  }
+}

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -39,6 +39,20 @@ executionStatusToBakeResults:
 
 defaultCloudProviderType: aws
 
+# When the bakery is configured to use a templateFile in this list,
+# /usr/bin/packer will be run as root using 'sudo'.
+# By default, spinnaker does not have sudo permissions so these scripts will
+# fail.
+# In order to give sudo permissions, create and add the following line (without
+# leading '#') to /etc/sudoers.d/spinnaker
+# spinnaker ALL=(ALL) NOPASSWD: /usr/bin/packer
+#
+# WARNING: Giving sudo access for spinnaker to execute packer may create an
+# opportunity for malicious actors to take control of your machine and data it
+# has access to.
+
+templatesNeedingRoot: aws-chroot.json
+
 aws:
   enabled: ${AWS_ENABLED:false}
   bakeryDefaults:

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -91,6 +91,7 @@ ospackage {
   }
 
   configurationFile('/opt/rosco/config/rosco.yml')
+  configurationFile('/opt/rosco/config/packer/aws-chroot.json')
   configurationFile('/opt/rosco/config/packer/aws-ebs.json')
   configurationFile('/opt/rosco/config/packer/gce.json')
   configurationFile('/opt/rosco/config/packer/install_packages.sh')


### PR DESCRIPTION
This makes packer run as sudo if it is a aws-chroot build. There is a corresponding pull request to the spinnaker repo to add the spinnaker user to sudoers https://github.com/spinnaker/spinnaker/pull/816.

mock script to test with:
```
#!/bin/bash
echo "Running mock"
env
echo "sleep"
sleep 5
echo "done sleeping"
echo "i am"
whoami
echo "sleep"
sleep 30
```

output of mock script:
```
Running mock
SHELL=/bin/sh
TERM=linux
USER=root
SUDO_USER=spinnaker
SUDO_UID=1001
USERNAME=root
MAIL=/var/mail/root
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
SHLVL=1
SUDO_COMMAND=/usr/local/bin/packer build -color=false -var aws_region=us-west-2 -var aws_ssh_username=ubuntu -var aws_instance_type=t2.micro -var aws_source_ami=ami-3d50120d -var aws_target_ami=trusty-vim-gard-2-all-1458387928895-trusty -var aws_associate_public_ip_address=true -var package_type=deb -var packages=vim -var configDir=/opt/rosco/config/packer /opt/rosco/config/packer/aws-chroot.json
HOME=/home/spinnaker
LOGNAME=root
SUDO_GID=1001
_=/usr/bin/env
sleep
done sleeping
i am
root
sleep
```