### PR TITLE
Force yum to preserve package installation order

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -61,7 +61,8 @@ EOF
     sudo yum -y update
   fi
 
-  sudo yum -y install $packages
+  # Enforce the package installation order.
+  for package in $packages; do sudo yum -y install $package; done
 }
 
 function main() {


### PR DESCRIPTION
This behavior is consitent with the debian one. Also yum correctly fail (also aborting the build)
if the package he's trying to install cannot be installed