### PR TITLE
Parse a FQPN at any position in the package list

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactory.groovy
@@ -39,14 +39,13 @@ public class DefaultImageNameFactory implements ImageNameFactory {
     def timestamp = clock.millis()
 
     List<String> packageNameList = bakeRequest?.package_name?.tokenize(" ")
-    PackageNameConverter.OsPackageName osPackageName
     String appVersionStr
-    AppVersion appVersion
-    def baseImagePackageName
+    String baseImagePackageName
 
     if (packageNameList) {
       packageNameList.eachWithIndex { packageName, index ->
 
+        PackageNameConverter.OsPackageName osPackageName
         osPackageName = PackageNameConverter.buildOsPackageName(selectedOptions.baseImage.packageType, packageName)
 
         if (osPackageName?.name) {
@@ -57,17 +56,16 @@ public class DefaultImageNameFactory implements ImageNameFactory {
             packageNameList[index] += "$selectedOptions.baseImage.packageType.versionDelimiter$osPackageName.version-$osPackageName.release"
           }
 
-          // First package is special, its name and its attributes may be used to build the AMI name and add additional
-          // attributes (eg: AppVersion)
+          // First package is special, its name and its attributes may be used to build the image name and add additional
+          // attributes (eg: appversion and build_host).
           if (index == 0) {
-            // We need to replace the original fully-qualified package name for with the unqualified
+            // We need to replace the original fully-qualified package name with the unqualified
             // package name before using it in the target image name.
             baseImagePackageName = osPackageName?.name ?: packageName
 
             appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageName)
-            appVersion = AppVersion.parseName(appVersionStr)
 
-            if (!appVersion) {
+            if (!AppVersion.parseName(appVersionStr)) {
               if (appVersionStr) {
                 log.debug("AppVersion.parseName() was unable to parse appVersionStr=$appVersionStr.")
               }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactory.groovy
@@ -39,35 +39,43 @@ public class DefaultImageNameFactory implements ImageNameFactory {
     def timestamp = clock.millis()
 
     List<String> packageNameList = bakeRequest?.package_name?.tokenize(" ")
-    def firstPackageName
     PackageNameConverter.OsPackageName osPackageName
     String appVersionStr
     AppVersion appVersion
+    def baseImagePackageName
 
     if (packageNameList) {
-      // For now, we only take into account the first package name when generating the appversion tag.
-      firstPackageName = packageNameList[0]
+      packageNameList.eachWithIndex { packageName, index ->
 
-      // Passing in firstPackageName here to avoid tokenizing the package name list twice.
-      osPackageName = PackageNameConverter.buildOsPackageName(selectedOptions.baseImage.packageType, firstPackageName)
-      appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageName)
-      appVersion = AppVersion.parseName(appVersionStr)
+        osPackageName = PackageNameConverter.buildOsPackageName(selectedOptions.baseImage.packageType, packageName)
 
-      if (!appVersion) {
-        if (appVersionStr) {
-          log.debug("AppVersion.parseName() was unable to parse appVersionStr=$appVersionStr.")
-        }
+        if (osPackageName?.name) {
+          packageNameList[index] = osPackageName.name
 
-        // If appVersionStr could not be parsed to create AppVersion, clear it.
-        appVersionStr = null
-      }
+          // If a version/release was specified, we need to include that when installing the package.
+          if (osPackageName?.version && osPackageName?.release) {
+            packageNameList[index] += "$selectedOptions.baseImage.packageType.versionDelimiter$osPackageName.version-$osPackageName.release"
+          }
 
-      if (osPackageName?.name) {
-        packageNameList[0] = osPackageName.name
+          // First package is special, its name and its attributes may be used to build the AMI name and add additional
+          // attributes (eg: AppVersion)
+          if (index == 0) {
+            // We need to replace the original fully-qualified package name for with the unqualified
+            // package name before using it in the target image name.
+            baseImagePackageName = osPackageName?.name ?: packageName
 
-        // If a version/release was specified, we need to include that when installing the package.
-        if (osPackageName?.version && osPackageName?.release) {
-          packageNameList[0] += "$selectedOptions.baseImage.packageType.versionDelimiter$osPackageName.version-$osPackageName.release"
+            appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageName)
+            appVersion = AppVersion.parseName(appVersionStr)
+
+            if (!appVersion) {
+              if (appVersionStr) {
+                log.debug("AppVersion.parseName() was unable to parse appVersionStr=$appVersionStr.")
+              }
+
+              // If appVersionStr could not be parsed to create AppVersion, clear it.
+              appVersionStr = null
+            }
+          }
         }
       }
     }
@@ -77,9 +85,6 @@ public class DefaultImageNameFactory implements ImageNameFactory {
     if (bakeRequest.ami_name) {
       imageName = "$bakeRequest.ami_name-"
     } else {
-      // We need to replace the original fully-qualified package name with the unqualified package name before using
-      // it in the target image name.
-      def baseImagePackageName = osPackageName?.name ?: firstPackageName
       imageName = baseImagePackageName ? "$baseImagePackageName-" : ""
     }
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/DefaultImageNameFactorySpec.groovy
@@ -159,6 +159,26 @@ class DefaultImageNameFactorySpec extends Specification {
       packagesParameter == "nflx-djangobase-enhanced=0.1-3 kato redis-server"
   }
 
+  void "should recognize fully-qualified ubuntu package name in any position plus extra packages"() {
+    setup:
+      def clockMock = Mock(Clock)
+      def imageNameFactory = new DefaultImageNameFactory(clock: clockMock)
+      def selectedOptions = new BakeOptions.Selected(baseImage: new BakeOptions.BaseImage(id: "ubuntu", packageType: "DEB"))
+      def bakeRequest = new BakeRequest(package_name: "kato nflx-djangobase-enhanced_0.1-3_all redis-server",
+                                        build_number: "12",
+                                        commit_hash: "170cdbd",
+                                        base_os: "ubuntu")
+
+    when:
+      def (imageName, appVersionStr, packagesParameter) = imageNameFactory.deriveImageNameAndAppVersion(bakeRequest, selectedOptions)
+
+    then:
+      1 * clockMock.millis() >> 123456
+      imageName == "kato-all-123456-ubuntu"
+      appVersionStr == null
+      packagesParameter == "kato nflx-djangobase-enhanced=0.1-3 redis-server"
+  }
+
   void "should recognize multiple fully-qualified ubuntu package names but only derive appversion from the first"() {
     setup:
       def clockMock = Mock(Clock)
@@ -176,7 +196,7 @@ class DefaultImageNameFactorySpec extends Specification {
       1 * clockMock.millis() >> 123456
       imageName == "nflx-djangobase-enhanced-all-123456-ubuntu"
       appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
-      packagesParameter == "nflx-djangobase-enhanced=0.1-3 some-package_0.3-h15.290fcab_all"
+      packagesParameter == "nflx-djangobase-enhanced=0.1-3 some-package=0.3-h15.290fcab"
   }
 
   void "should identify version on fully-qualified ubuntu package name without build number and commit hash"() {


### PR DESCRIPTION
This patch is a step forward in correct handling multiple packages. With this patch if a FullQualifiedPackageName get passed in the
package list it get parsed no matter the position (before it only happened for the first one).
Also, the first package keep its importance of potential determining the ami-name or the Appversion if correctly parsed

This is related to: https://github.com/spinnaker/orca/pull/800 : packages can come down in any order