### PR TITLE
Improve the unicity of the bake key also taking into account multiple accounts

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -79,7 +79,7 @@ abstract class CloudProviderBakeHandler {
         bakeKey += ":$ami_name"
       }
 
-      String packages = package_name.tokenize().join('-')
+      String packages = package_name.tokenize().join('|')
       bakeKey += ":$packages"
 
       def providerSpecificBakeKeyComponent = produceProviderSpecificBakeKeyComponent(region, bakeRequest)

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -77,9 +77,10 @@ abstract class CloudProviderBakeHandler {
 
       if (ami_name) {
         bakeKey += ":$ami_name"
-      } else {
-        bakeKey += ":$package_name"
       }
+
+      String packages = package_name.tokenize().join('-')
+      bakeKey += ":$packages"
 
       def providerSpecificBakeKeyComponent = produceProviderSpecificBakeKeyComponent(region, bakeRequest)
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -749,7 +749,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'produce a default AWS bakeKey with base ami'() {
@@ -768,7 +768,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:ami-123456:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:ami-123456:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'produce a default AWS bakeKey with enhanced network enabled'() {
@@ -787,7 +787,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWEnabled"
+      bakeKey == "bake:aws:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:us-east-1:hvm:enhancedNWEnabled"
   }
 
   void 'produce a default AWS bakeKey with ami name'() {
@@ -805,7 +805,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato-app:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:kato-app:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'do not consider ami suffix when composing bake key'() {
@@ -830,7 +830,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey2 = awsBakeHandler.produceBakeKey(REGION, bakeRequest2)
 
     then:
-      bakeKey1 == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey1 == "bake:aws:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:us-east-1:hvm:enhancedNWDisabled"
       bakeKey2 == bakeKey1
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -29,7 +29,7 @@ import spock.lang.Subject
 
 class AWSBakeHandlerSpec extends Specification {
 
-  private static final String PACKAGE_NAME = "kato"
+  private static final String PACKAGES_NAME = "kato nflx-djangobase-enhanced_0.1-h12.170cdbd_all mongodb"
   private static final String REGION = "us-east-1"
   private static final String SOURCE_UBUNTU_HVM_IMAGE_NAME = "ami-a123456b"
   private static final String SOURCE_UBUNTU_PV_IMAGE_NAME = "ami-a654321b"
@@ -283,7 +283,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -296,7 +296,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -311,7 +311,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -320,7 +320,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "amzn",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -333,7 +333,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: YUM_REPOSITORY,
         package_type: BakeRequest.PackageType.RPM.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -348,7 +348,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -380,7 +380,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-        package_name: PACKAGE_NAME,
+        package_name: PACKAGES_NAME,
         base_os: "amzn",
         vm_type: BakeRequest.VmType.hvm,
         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -393,7 +393,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: YUM_REPOSITORY,
         package_type: BakeRequest.PackageType.RPM.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -409,7 +409,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("sudo", parameterMap, "$configDir/aws-chroot.json")
   }
 
@@ -418,7 +418,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         base_ami: "ami-12345678",
                                         vm_type: BakeRequest.VmType.hvm,
@@ -432,7 +432,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -447,7 +447,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -456,7 +456,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         vm_type: BakeRequest.VmType.pv,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -469,7 +469,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -484,7 +484,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -493,7 +493,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         vm_type: BakeRequest.VmType.pv,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -507,7 +507,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -522,7 +522,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/somePackerTemplate.json")
   }
 
@@ -531,7 +531,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         vm_type: BakeRequest.VmType.pv,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -545,7 +545,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir,
         someAttr1: "someValue1",
         someAttr2: "someValue2"
@@ -562,7 +562,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -571,7 +571,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -584,7 +584,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -599,7 +599,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -652,7 +652,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -666,7 +666,7 @@ class AWSBakeHandlerSpec extends Specification {
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         upgrade: true,
         configDir: configDir
       ]
@@ -682,7 +682,7 @@ class AWSBakeHandlerSpec extends Specification {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
@@ -691,7 +691,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -715,7 +715,7 @@ class AWSBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         vm_type: BakeRequest.VmType.pv,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -737,7 +737,7 @@ class AWSBakeHandlerSpec extends Specification {
   void 'produce a default AWS bakeKey without base ami'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
@@ -749,13 +749,13 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'produce a default AWS bakeKey with base ami'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -768,13 +768,13 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:ami-123456:kato:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:ami-123456:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'produce a default AWS bakeKey with enhanced network enabled'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -787,13 +787,13 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato:us-east-1:hvm:enhancedNWEnabled"
+      bakeKey == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWEnabled"
   }
 
   void 'produce a default AWS bakeKey with ami name'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         vm_type: BakeRequest.VmType.hvm,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -805,19 +805,19 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey = awsBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:aws:centos:kato-app:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey == "bake:aws:centos:kato-app:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
   }
 
   void 'do not consider ami suffix when composing bake key'() {
     setup:
       def bakeRequest1 = new BakeRequest(user: "someuser@gmail.com",
-                                         package_name: PACKAGE_NAME,
+                                         package_name: PACKAGES_NAME,
                                          base_os: "centos",
                                          vm_type: BakeRequest.VmType.hvm,
                                          cloud_provider_type: BakeRequest.CloudProviderType.aws,
                                          ami_suffix: "1.0")
       def bakeRequest2 = new BakeRequest(user: "someuser@gmail.com",
-                                         package_name: PACKAGE_NAME,
+                                         package_name: PACKAGES_NAME,
                                          base_os: "centos",
                                          vm_type: BakeRequest.VmType.hvm,
                                          cloud_provider_type: BakeRequest.CloudProviderType.aws,
@@ -830,7 +830,7 @@ class AWSBakeHandlerSpec extends Specification {
       String bakeKey2 = awsBakeHandler.produceBakeKey(REGION, bakeRequest2)
 
     then:
-      bakeKey1 == "bake:aws:centos:kato:us-east-1:hvm:enhancedNWDisabled"
+      bakeKey1 == "bake:aws:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb:us-east-1:hvm:enhancedNWDisabled"
       bakeKey2 == bakeKey1
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 
 class DockerBakeHandlerSpec extends Specification {
 
-  private static final String PACKAGE_NAME = "kato"
+  private static final String PACKAGES_NAME = "kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb"
   private static final String REGION = "global"
   private static final String TARGET_REPOSITORY = "my-docker-repository:5000"
   private static final String TEMPLATE_FILE = "docker_template.json"
@@ -148,7 +148,7 @@ class DockerBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-ubuntu"
@@ -158,7 +158,7 @@ class DockerBakeHandlerSpec extends Specification {
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -173,7 +173,7 @@ class DockerBakeHandlerSpec extends Specification {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
                                                       parameterMap,
                                                       "$configDir/$dockerBakeryDefaults.templateFile")
@@ -184,7 +184,7 @@ class DockerBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-trusty"
@@ -194,7 +194,7 @@ class DockerBakeHandlerSpec extends Specification {
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -209,7 +209,7 @@ class DockerBakeHandlerSpec extends Specification {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
                                                       parameterMap,
                                                       "$configDir/$dockerBakeryDefaults.templateFile")
@@ -220,7 +220,7 @@ class DockerBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-centos"
@@ -230,7 +230,7 @@ class DockerBakeHandlerSpec extends Specification {
         docker_target_repository: TARGET_REPOSITORY,
         repository: YUM_REPOSITORY,
         package_type: BakeRequest.PackageType.RPM.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -245,7 +245,7 @@ class DockerBakeHandlerSpec extends Specification {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
                                                       parameterMap,
                                                       "$configDir/$dockerBakeryDefaults.templateFile")
@@ -299,7 +299,7 @@ class DockerBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "wily",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -521,7 +521,7 @@ class GCEBakeHandlerSpec extends Specification {
       String bakeKey = gceBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:gce:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb"
+      bakeKey == "bake:gce:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb"
   }
 
   void 'produce a default GCE bakeKey with base image'() {
@@ -539,7 +539,7 @@ class GCEBakeHandlerSpec extends Specification {
       String bakeKey = gceBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:gce:centos:my-base-image:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb"
+      bakeKey == "bake:gce:centos:my-base-image:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb"
   }
 
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class GCEBakeHandlerSpec extends Specification {
 
-  private static final String PACKAGE_NAME = "kato"
+  private static final String PACKAGES_NAME = "kato nflx-djangobase-enhanced_0.1-h12.170cdbd_all mongodb"
   private static final String REGION = "us-central1"
   private static final String SOURCE_UBUNTU_IMAGE_NAME = "some-ubuntu-image"
   private static final String SOURCE_TRUSTY_IMAGE_NAME = "some-trusty-image"
@@ -154,7 +154,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def targetImageName = "kato-x8664-timestamp-ubuntu"
@@ -166,7 +166,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -182,7 +182,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -191,7 +191,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def targetImageName = "kato-x8664-timestamp-centos"
@@ -203,7 +203,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: YUM_REPOSITORY,
         package_type: BakeRequest.PackageType.RPM.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -219,7 +219,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -228,7 +228,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         base_ami: "some-gce-image-name",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
@@ -241,7 +241,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -257,7 +257,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -266,7 +266,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce,
                                         template_file_name: "somePackerTemplate.json")
@@ -279,7 +279,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -295,7 +295,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/somePackerTemplate.json")
   }
 
@@ -304,7 +304,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce,
                                         extended_attributes: [someAttr1: "someValue1", someAttr2: "someValue2"])
@@ -317,7 +317,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir,
         someAttr1: "someValue1",
         someAttr2: "someValue2"
@@ -335,7 +335,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -344,7 +344,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce,
                                         extended_attributes: [gce_zone: "europe-west1-b", gce_network: "other-network"])
@@ -357,7 +357,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -373,7 +373,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -382,7 +382,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def targetImageName = "kato-x8664-timestamp-trusty"
@@ -394,7 +394,7 @@ class GCEBakeHandlerSpec extends Specification {
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
         package_type: BakeRequest.PackageType.DEB.packageType,
-        packages: PACKAGE_NAME,
+        packages: PACKAGES_NAME,
         configDir: configDir
       ]
 
@@ -410,7 +410,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+      1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
@@ -463,7 +463,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "wily",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
 
@@ -486,7 +486,7 @@ class GCEBakeHandlerSpec extends Specification {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def targetImageName = "kato-x8664-timestamp-trusty"
@@ -502,7 +502,7 @@ class GCEBakeHandlerSpec extends Specification {
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-    1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGE_NAME]
+    1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
       IllegalArgumentException e = thrown()
       e.message == "No Google account specified for bakery."
   }
@@ -510,7 +510,7 @@ class GCEBakeHandlerSpec extends Specification {
   void 'produce a default GCE bakeKey without base image'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
 
@@ -521,13 +521,13 @@ class GCEBakeHandlerSpec extends Specification {
       String bakeKey = gceBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:gce:centos:kato"
+      bakeKey == "bake:gce:centos:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb"
   }
 
   void 'produce a default GCE bakeKey with base image'() {
     setup:
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
-                                        package_name: PACKAGE_NAME,
+                                        package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce,
                                         base_ami: "my-base-image")
@@ -539,7 +539,7 @@ class GCEBakeHandlerSpec extends Specification {
       String bakeKey = gceBakeHandler.produceBakeKey(REGION, bakeRequest)
 
     then:
-      bakeKey == "bake:gce:centos:my-base-image:kato"
+      bakeKey == "bake:gce:centos:my-base-image:kato-nflx-djangobase-enhanced_0.1-h12.170cdbd_all-mongodb"
   }
 
 }


### PR DESCRIPTION
This PR address the following issue: Given two bakes with the same ami-name but different installed package(s), the bakeKey should be different, otherwise a rebake is required to bake it again (also the ami-suffix is not part of the bakeKey).
This is very evident when baking from the Bake stage of a pipeline. The ami-name is constant at this point, while the installed packages version is different for each build

