### PR TITLE
Add support for password on a redis connection

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/config/JedisConfig.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/config/JedisConfig.groovy
@@ -29,13 +29,14 @@ import redis.clients.jedis.JedisPool
 class JedisConfig {
 
   @Bean
-  JedisPool jedisPool(@Value('${redis.connection:redis://localhost:6379}') String connection) {
+  JedisPool jedisPool(@Value('${redis.connection:redis://localhost:6379}') String connection,
+                      @Value('${redis.timeout:2000}') int timeout) {
     RedisConnectionInfo connectionInfo = RedisConnectionInfo.parseConnectionUri(connection)
     GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig()
     poolConfig.setMaxTotal(100)
     poolConfig.setMinIdle(25)
     poolConfig.setMaxIdle(100)
-    new JedisPool(poolConfig, connectionInfo.host, connectionInfo.port)
+    new JedisPool(poolConfig, connectionInfo.host, connectionInfo.port, timeout, connectionInfo.password)
   }
 
   @Bean


### PR DESCRIPTION
Needed to add a timeout value since the JedisPool constructor requires one if you want to include a password.  This change supports using the Azure hosted Redis service.