### PR TITLE
Remove config files with possible credentials from baked AMIs

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -43,6 +43,9 @@ function provision_deb() {
     echo "removing /usr/sbin/policy-rc.d"
     sudo rm -f /usr/sbin/policy-rc.d
   fi
+
+  # Cleanup repository configuration
+  sudo rm /etc/apt/sources.list.d/spinnaker.list
 }
 
 function provision_rpm() {
@@ -63,6 +66,9 @@ EOF
 
   # Enforce the package installation order.
   for package in $packages; do sudo yum -y install $package; done
+
+  # Cleanup repository configuration
+  sudo rm /etc/yum.repos.d/spinnaker.repo
 }
 
 function main() {

--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -44,8 +44,10 @@ function provision_deb() {
     sudo rm -f /usr/sbin/policy-rc.d
   fi
 
-  # Cleanup repository configuration
-  sudo rm /etc/apt/sources.list.d/spinnaker.list
+  if [[ "$repository" != "" ]]; then
+    # Cleanup repository configuration
+    sudo rm /etc/apt/sources.list.d/spinnaker.list
+  fi
 }
 
 function provision_rpm() {
@@ -67,8 +69,10 @@ EOF
   # Enforce the package installation order.
   for package in $packages; do sudo yum -y install $package; done
 
-  # Cleanup repository configuration
-  sudo rm /etc/yum.repos.d/spinnaker.repo
+  if [[ "$repository" != "" ]]; then
+    # Cleanup repository configuration
+    sudo rm /etc/yum.repos.d/spinnaker.repo
+  fi
 }
 
 function main() {


### PR DESCRIPTION
Remove configuration files from either debian and yum repos after installing packages. We are doing this because we put basic auth credentials in repo urls.