### PR TITLE
Travis support for rosco

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -42,6 +42,8 @@ class BakeRequest {
   String build_number
   @ApiModelProperty("The commit hash of the CI build")
   String commit_hash
+  @ApiModelProperty("The CI Build Url")
+  String build_info_url
   @ApiModelProperty("The target platform")
   CloudProviderType cloud_provider_type
   Label base_label

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -118,6 +118,10 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
       parameterMap.aws_enhanced_networking = true
     }
 
+    if (bakeRequest.build_info_url) {
+      parameterMap.build_info_url = bakeRequest.build_info_url
+    }
+
     return parameterMap
   }
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco.providers.util
 
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import groovy.transform.EqualsAndHashCode
+import org.springframework.util.StringUtils
 
 class PackageNameConverter {
 
@@ -118,7 +119,10 @@ class PackageNameConverter {
           }
 
           if (bakeRequest.job) {
-            appVersion += "/$bakeRequest.job/$bakeRequest.build_number"
+            // Travis job name and Jenkins job name with folder may contain slashes into the job name
+            // that makes the AppVersion.parseName fails, so, replace all slashes in the job name for hyphens
+            def job = bakeRequest.job.replaceAll("/", "-")
+            appVersion += "/$job/$bakeRequest.build_number"
           }
         }
       }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -604,18 +604,20 @@ class AWSBakeHandlerSpec extends Specification {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
-  void 'produces packer command with all required parameters including appversion and build_host for trusty'() {
+  void 'produces packer command with all required parameters including appversion, build_host and build_info_url for trusty'() {
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def fullyQualifiedPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
       def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
       def buildHost = "http://some-build-server:8080"
+      def buildInfoUrl = "http://some-build-server:8080/repogroup/repo/builds/320282"
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: fullyQualifiedPackageName,
                                         base_os: "trusty",
                                         vm_type: BakeRequest.VmType.hvm,
                                         build_host: buildHost,
+                                        build_info_url: buildInfoUrl,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def parameterMap = [
@@ -629,7 +631,8 @@ class AWSBakeHandlerSpec extends Specification {
         packages: fullyQualifiedPackageName,
         configDir: configDir,
         appversion: appVersionStr,
-        build_host: buildHost
+        build_host: buildHost,
+        build_info_url: buildInfoUrl
       ]
 
       @Subject

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
@@ -122,6 +122,21 @@ class PackageNameConverterSpec extends Specification {
       appVersionStrFromDebPackageName == appVersionStr
   }
 
+  void "if job name contains slashes, they are replaced by hyphen"() {
+    setup:
+      def debPackageName = "nflx-djangobase-enhanced_0.1-h123.170cdbd_all"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-h123.170cdbd/compose-job-name/123"
+      def packageType = BakeRequest.PackageType.DEB
+      def bakeRequest = new BakeRequest(base_os: "ubuntu", job: "compose/job/name", build_number: "123", commit_hash: "170cdbd")
+
+    when:
+      def parsedDebPackageName = PackageNameConverter.buildOsPackageName(packageType, debPackageName)
+      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName)
+
+    then:
+      appVersionStrFromDebPackageName == appVersionStr
+  }
+
   void "if job is missing, app version string leaves off both job and build_number"() {
     setup:
       def debPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"

--- a/rosco-web/config/packer/aws-chroot.json
+++ b/rosco-web/config/packer/aws-chroot.json
@@ -26,7 +26,11 @@
     "secret_key": "{{user `aws_secret_key`}}",
     "source_ami": "{{user `aws_source_ami`}}",
     "ami_name": "{{user `aws_target_ami`}}",
-    "tags": {"appversion": "{{user `appversion`}}", "build_host": "{{user `build_host`}}"}
+    "tags": {
+      "appversion": "{{user `appversion`}}",
+      "build_host": "{{user `build_host`}}",
+      "build_info_url": "{{user `build_info_url`}}"
+    }
   }],
   "provisioners": [{
     "type": "shell",

--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -33,7 +33,11 @@
     "ami_name": "{{user `aws_target_ami`}}",
     "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
     "enhanced_networking": "{{user `aws_enhanced_networking`}}",
-    "tags": {"appversion": "{{user `appversion`}}", "build_host": "{{user `build_host`}}"},
+    "tags": {
+      "appversion": "{{user `appversion`}}",
+      "build_host": "{{user `build_host`}}",
+      "build_info_url": "{{user `build_info_url`}}"
+    },
     "run_tags": {"Packages": "{{user `packages`}}"}
   }],
   "provisioners": [{


### PR DESCRIPTION
Part of a series of PR adding build info support for travis integration on AWS
by adding new build_info_url tag to the images in order to be able to full fill the build info correctly for travis.

This PR adds a build_info_url BakeRequest to Rosco
Rosco will add the build_infor_url as a ec2 tag.

This is the final result
![screen shot 2016-06-02 at 10 11 01](https://cloud.githubusercontent.com/assets/10425379/15742361/b34ce618-28be-11e6-9cd6-b1d56a32a397.png)

Related PRs:
https://github.com/spinnaker/orca/pull/856
https://github.com/spinnaker/clouddriver/pull/652
https://github.com/spinnaker/deck/pull/2304