### PR TITLE
Changed provision_deb so it can take multiple repos

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -27,7 +27,10 @@ function provision_deb() {
   fi
 
   if [[ "$repository" != "" ]]; then
-    echo "deb $repository" | sudo tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
+    IFS=';' read -ra repo <<< "$repository"
+    for i in "${repo[@]}"; do
+      echo "deb $i" | sudo tee -a /etc/apt/sources.list.d/spinnaker.list > /dev/null
+    done
   fi
 
   sudo apt-get update


### PR DESCRIPTION
Have change the provision_deb functions so it loops over $repository split on ;

This makes it possible to set more the one deb repo in debianRepository and have them all added. I did split the settings string on ; with to my knowledge is a non valid character for the urls and there by safe as a character to split on.

Please add comments.