### PR TITLE
Set HOME env when running from deb package.

### DIFF
--- a/rosco-web/etc/init/rosco.conf
+++ b/rosco-web/etc/init/rosco.conf
@@ -9,4 +9,5 @@ expect fork
 
 stop on stopping spinnaker
 
+env HOME=/home/spinnaker
 exec /opt/rosco/bin/rosco 2>&1 > /var/log/spinnaker/rosco/rosco.log &


### PR DESCRIPTION
When I merged the job-runner logic from rush into rosco, I neglected to add the config to set HOME env when running rosco from an installed .deb package.
This omission left the aws builder for packer unable to resolve .aws/credentials: https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/shared_credentials_provider.go#L125