### PR TITLE
Removing the handling of the docker service from the DockerBakeHandler

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -30,8 +30,6 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
   private static final String BUILDER_TYPE = "docker"
   private static final String IMAGE_NAME_TOKEN = "Repository:"
 
-  static final String START_DOCKER_SERVICE_BASE_COMMAND = "sudo service docker start ; "
-
   @Autowired
   RoscoDockerConfiguration.DockerBakeryDefaults dockerBakeryDefaults
 
@@ -72,11 +70,6 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
       docker_target_image     : imageName,
       docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
-  }
-
-  @Override
-  String getBaseCommand() {
-    return START_DOCKER_SERVICE_BASE_COMMAND
   }
 
   @Override

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -174,9 +174,7 @@ class DockerBakeHandlerSpec extends Specification {
 
     then:
       1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
-      1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
-                                                      parameterMap,
-                                                      "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty'() {
@@ -210,9 +208,7 @@ class DockerBakeHandlerSpec extends Specification {
 
     then:
       1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
-      1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
-                                                      parameterMap,
-                                                      "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for centos'() {
@@ -246,9 +242,7 @@ class DockerBakeHandlerSpec extends Specification {
 
     then:
       1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >> [targetImageName, null, PACKAGES_NAME]
-      1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
-                                                      parameterMap,
-                                                      "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including appversion and build_host for trusty'() {
@@ -289,9 +283,7 @@ class DockerBakeHandlerSpec extends Specification {
     then:
       1 * imageNameFactoryMock.deriveImageNameAndAppVersion(bakeRequest, _) >>
         [targetImageName, appVersionStr, fullyQualifiedPackageName]
-      1 * packerCommandFactoryMock.buildPackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND,
-                                                      parameterMap,
-                                                      "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'throws exception when virtualization settings are not found for specified operating system'() {
@@ -310,7 +302,7 @@ class DockerBakeHandlerSpec extends Specification {
                                                                   debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(DockerBakeHandler.START_DOCKER_SERVICE_BASE_COMMAND, bakeRequest)
+      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()


### PR DESCRIPTION
The 'START_DOCKER_SERVICE_BASE_COMMAND' breaks for us when running docker bakes, so locally I removed it rather than trying to find a way to have it work, as I felt that it didn't belong under the responsibility of Rosco to ensure that the docker service was running. And as @duftler pointed out on the slack channel yesterday:
> That is almost certainly a vestige of rush's prior incarnation of running bake jobs as containers themselves.