### PR TITLE
Support the share_with and copy_to parameters as extended_attributes.

### DIFF
--- a/rosco-web/config/packer/aws-chroot.json
+++ b/rosco-web/config/packer/aws-chroot.json
@@ -17,7 +17,22 @@
     "package_type": "",
     "packages": "",
     "upgrade": "",
-    "configDir": null
+    "configDir": null,
+    "share_with_1": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_2": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_3": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_4": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_5": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_6": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_7": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_8": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_9": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_10": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "copy_to_1": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_2": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_3": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_4": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_5": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}"
   },
   "builders": [{
     "type": "amazon-chroot",
@@ -26,6 +41,25 @@
     "secret_key": "{{user `aws_secret_key`}}",
     "source_ami": "{{user `aws_source_ami`}}",
     "ami_name": "{{user `aws_target_ami`}}",
+    "ami_users": [
+      "{{user `share_with_1`}}",
+      "{{user `share_with_2`}}",
+      "{{user `share_with_3`}}",
+      "{{user `share_with_4`}}",
+      "{{user `share_with_5`}}",
+      "{{user `share_with_6`}}",
+      "{{user `share_with_7`}}",
+      "{{user `share_with_8`}}",
+      "{{user `share_with_9`}}",
+      "{{user `share_with_10`}}"
+    ],
+    "ami_regions": [
+      "{{user `copy_to_1`}}",
+      "{{user `copy_to_2`}}",
+      "{{user `copy_to_3`}}",
+      "{{user `copy_to_4`}}",
+      "{{user `copy_to_5`}}"
+    ],
     "tags": {
       "appversion": "{{user `appversion`}}",
       "build_host": "{{user `build_host`}}",

--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -17,7 +17,22 @@
     "package_type": "",
     "packages": "",
     "upgrade": "",
-    "configDir": null
+    "configDir": null,
+    "share_with_1": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_2": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_3": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_4": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_5": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_6": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_7": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_8": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_9": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "share_with_10": "{{env `SPINNAKER_AWS_DEFAULT_ACCOUNT`}}",
+    "copy_to_1": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_2": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_3": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_4": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}",
+    "copy_to_5": "{{env `SPINNAKER_AWS_DEFAULT_REGION`}}"
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -31,6 +46,25 @@
     "instance_type": "{{user `aws_instance_type`}}",
     "source_ami": "{{user `aws_source_ami`}}",
     "ami_name": "{{user `aws_target_ami`}}",
+    "ami_users": [
+      "{{user `share_with_1`}}",
+      "{{user `share_with_2`}}",
+      "{{user `share_with_3`}}",
+      "{{user `share_with_4`}}",
+      "{{user `share_with_5`}}",
+      "{{user `share_with_6`}}",
+      "{{user `share_with_7`}}",
+      "{{user `share_with_8`}}",
+      "{{user `share_with_9`}}",
+      "{{user `share_with_10`}}"
+    ],
+    "ami_regions": [
+      "{{user `copy_to_1`}}",
+      "{{user `copy_to_2`}}",
+      "{{user `copy_to_3`}}",
+      "{{user `copy_to_4`}}",
+      "{{user `copy_to_5`}}"
+    ],
     "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
     "enhanced_networking": "{{user `aws_enhanced_networking`}}",
     "tags": {


### PR DESCRIPTION
The packer part is quite ugly since it's not possible to pass a list on the command line as `var`.
Accounts and regions must me passed one by one