### PR TITLE
Update logrotate file permissions

### DIFF
--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -88,6 +88,7 @@ ospackage {
     into('/etc/logrotate.d')
     user = 'root'
     permissionGroup = 'root'
+    fileMode = 0644
     fileType = CONFIG | NOREPLACE
   }
 


### PR DESCRIPTION
This change will fix problems where logrotate ignores
/etc/logrotate.d/rosco due to 'bad file mode.'

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)