### PR TITLE
Adding custom naming conventions for docker provider

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -120,7 +120,7 @@ abstract class CloudProviderBakeHandler {
   /**
    * Returns a map containing the parameters that should be propagated to the packer template for this provider.
    */
-  abstract Map buildParameterMap(String region, def virtualizationSettings, String imageName, BakeRequest bakeRequest)
+  abstract Map buildParameterMap(String region, def virtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag)
 
   /**
    * Returns the command that should be prepended to the shell command passed to the container.
@@ -151,26 +151,20 @@ abstract class CloudProviderBakeHandler {
 
     def osPackageNames = PackageNameConverter.buildOsPackageNames(packageType, packageNameList)
 
+    def imageTag = imageNameFactory.buildImageTag(bakeRequest, osPackageNames)
+
     def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackageNames)
 
-    def imageName = imageNameFactory.buildImageName(bakeRequest, osPackageNames)
+    def parameterMap = buildParameterMap(region, virtualizationSettings, appVersionStr, bakeRequest, imageTag)
 
-    def packagesParameter = imageNameFactory.buildPackagesParameter(packageType, osPackageNames)
-
-    def parameterMap = buildParameterMap(region, virtualizationSettings, imageName, bakeRequest)
-
-    if (debianRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.DEB) {
+    if (debianRepository && packageType == BakeRequest.PackageType.DEB) {
       parameterMap.repository = debianRepository
-    } else if (yumRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.RPM) {
+    } else if (yumRepository && packageType == BakeRequest.PackageType.RPM) {
       parameterMap.repository = yumRepository
     }
 
-    parameterMap.package_type = selectedOptions.baseImage.packageType.packageType
-    parameterMap.packages = packagesParameter
-
-    if (appVersionStr) {
-      parameterMap.appversion = appVersionStr
-    }
+    parameterMap.package_type = packageType.packageType
+    parameterMap.packages = imageNameFactory.buildPackagesParameter(packageType, osPackageNames)
 
     if (bakeRequest.build_host) {
       parameterMap.build_host = bakeRequest.build_host
@@ -182,18 +176,14 @@ abstract class CloudProviderBakeHandler {
 
     parameterMap.configDir = configDir
 
-    if (bakeRequest.extended_attributes) {
-      if (bakeRequest.extended_attributes.containsKey('share_with')) {
-        unrollParameters("share_with_", bakeRequest.extended_attributes.get('share_with'), parameterMap)
+    bakeRequest.extended_attributes?.entrySet()?.forEach { attribute ->
+      switch (attribute.getKey()) {
+        case ['copy_to', 'share_with']:
+          parameterMap.putAll(unrollParameters(attribute))
+          break
+        default:
+          parameterMap.put(attribute.getKey(), attribute.getValue())
       }
-
-      if (bakeRequest.extended_attributes.containsKey('copy_to')) {
-        unrollParameters("copy_to_", bakeRequest.extended_attributes.get('copy_to'), parameterMap)
-      }
-
-      List attributes = bakeRequest.extended_attributes.keySet().asList()
-      parameterMap << bakeRequest.extended_attributes.subMap(
-              attributes.findAll { !it.equals('share_with') && !it.equals('copy_to') })
     }
 
     def finalTemplateFileName = "$configDir/${bakeRequest.template_file_name ?: templateFileName}"
@@ -205,11 +195,15 @@ abstract class CloudProviderBakeHandler {
                                                    finalTemplateFileName)
   }
 
-  private void unrollParameters(String prefix, String rolledParameter, Map parameterMap) {
-    List<String> values = rolledParameter.tokenize(",")
-    values.eachWithIndex { value, index, counter = index + 1 ->
-      parameterMap.put(prefix + counter, value.trim())
+  protected Map unrollParameters(Map.Entry entry) {
+    String keyPrefix = entry.key + "_"
+    Map parameters = new HashMap()
+    entry.value.tokenize(",").eachWithIndex { String value, int i ->
+      int keyNumber = i + 1
+      parameters.put(keyPrefix + keyNumber, value.trim())
     }
+
+    return parameters
   }
 
   BaseImage findBaseImage(BakeRequest bakeRequest) {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -91,7 +91,7 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def awsVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def awsVirtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag) {
     def parameterMap = [
       aws_region       : region,
       aws_ssh_username : awsVirtualizationSettings.sshUserName,
@@ -123,6 +123,10 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
 
     if (bakeRequest.build_info_url) {
       parameterMap.build_info_url = bakeRequest.build_info_url
+    }
+
+    if (imageTag) {
+      parameterMap.appversion = imageTag
     }
 
     return parameterMap

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -80,7 +80,7 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
   }
 
   @Override
-  Map buildParameterMap(String region, Object virtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, Object virtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag) {
 
     def selectedImage = azureBakeryDefaults?.baseImages?.find { it.baseImage.id == bakeRequest.base_os }
 
@@ -100,6 +100,10 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
       azure_image_sku: selectedImage?.baseImage?.sku,
       azure_image_name: "$bakeRequest.build_number-$bakeRequest.base_name"
     ]
+
+    if (imageTag) {
+      parameterMap.appversion = imageTag
+    }
 
     return parameterMap
   }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -31,7 +31,7 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
   private static final String BUILDER_TYPE = "docker"
   private static final String IMAGE_NAME_TOKEN = "Repository:"
 
-  ImageNameFactory imageNameFactory = new ImageNameFactory()
+  ImageNameFactory imageNameFactory = new DockerImageNameFactory()
 
   @Autowired
   RoscoDockerConfiguration.DockerBakeryDefaults dockerBakeryDefaults
@@ -67,12 +67,15 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
-    return [
+  Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag) {
+    Map parameterMap = [
       docker_source_image     : dockerVirtualizationSettings.sourceImage,
+      docker_target_repository: dockerBakeryDefaults.targetRepository,
+      docker_target_image_tag : imageTag,
       docker_target_image     : imageName,
-      docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
+
+    return parameterMap
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.rosco.providers.docker
+
+import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
+import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+
+class DockerImageNameFactory extends ImageNameFactory {
+
+  @Override
+  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+    String ami_name = bakeRequest.ami_name ?: osPackageNames.first()?.name
+
+    def attributes = bakeRequest.getExtended_attributes()
+    String docker_organization = attributes?.get('docker_target_organization') ?: ""
+    String docker_image_name = attributes?.get('docker_target_image_name') ?: ami_name
+
+    return [docker_organization, docker_image_name].findAll{it}.join("/")
+  }
+
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -71,7 +71,7 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def gceVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def gceVirtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag) {
     RoscoGoogleConfiguration.ManagedGoogleAccount managedGoogleAccount = googleConfigurationProperties?.accounts?.getAt(0)
 
     if (!managedGoogleAccount) {
@@ -92,6 +92,10 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
 
     if (gceBakeryDefaults.useInternalIp != null) {
       parameterMap.gce_use_internal_ip = gceBakeryDefaults.useInternalIp
+    }
+
+    if (imageTag) {
+      parameterMap.appversion = imageTag
     }
 
     return parameterMap

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandler.groovy
@@ -86,7 +86,7 @@ public class OpenstackBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def openstackVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def openstackVirtualizationSettings, String imageName, BakeRequest bakeRequest, String imageTag) {
     def parameterMap = [
       openstack_identity_endpoint: openstackBakeryDefaults.identityEndpoint,
       openstack_region: region,
@@ -125,7 +125,12 @@ public class OpenstackBakeHandler extends CloudProviderBakeHandler {
       parameterMap.build_info_url = bakeRequest.build_info_url
     }
 
+    if (imageTag) {
+      parameterMap.appversion = imageTag
+    }
+
     return parameterMap
+
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactory.groovy
@@ -34,24 +34,24 @@ public class ImageNameFactory {
   Clock clock = Clock.systemUTC()
 
   /**
-   * Attempts to produce an appVersionStr from the first packageName; to be used for tagging the newly-baked image
+   * Attempts to produce an image tag from the first packageName; to be used for tagging the newly-baked image
    */
-  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
-    String appVersionStr = null
+  def buildImageTag(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+    String imageTag = null
 
     if (osPackageNames) {
-      appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageNames.first())
+      imageTag = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageNames.first())
     }
 
-    return appVersionStr
+    return imageTag
   }
 
   /**
-   * Produces an imageName either from the BakeRequest.ami_name or the first package to be installed.
+   * Produces an appVersionStr either from the BakeRequest.ami_name or the first package to be installed.
    * This is to be used for naming the image being baked. Note that this function is not required to
    * return the same image name on multiple invocations with the same bake request
    */
-  def buildImageName(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
     String timestamp = clock.millis()
     String baseImageName = osPackageNames ? osPackageNames.first()?.name : ""
     String baseImageArch = osPackageNames ? osPackageNames.first()?.arch : "all"

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -312,8 +312,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -352,8 +352,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -417,8 +417,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("sudo", parameterMap, null, "$configDir/aws-chroot.json")
   }
@@ -458,8 +458,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -498,8 +498,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -539,8 +539,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
   }
@@ -582,8 +582,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -622,8 +622,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -671,8 +671,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -713,8 +713,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -937,8 +937,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
@@ -991,8 +991,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       awsBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.rosco.api.BakeOptions
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
 import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
-import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
 import com.netflix.spinnaker.rosco.providers.util.PackerCommandFactory
 import com.netflix.spinnaker.rosco.providers.util.TestDefaults
 import spock.lang.Shared
@@ -209,8 +208,8 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
       azureBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(BakeRequest.PackageType.DEB, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/azure-linux.json")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -150,11 +150,12 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
-      def targetImageName = "kato-x8664-timestamp-ubuntu"
+      def targetImageName = "kato"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
         docker_target_image: targetImageName,
+        docker_target_image_tag: SOME_MILLISECONDS,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
@@ -173,8 +174,8 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -187,11 +188,12 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
-      def targetImageName = "kato-x8664-timestamp-trusty"
+      def targetImageName = "kato"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
+        docker_target_image_tag: SOME_MILLISECONDS,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
@@ -210,8 +212,8 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -224,11 +226,12 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
-      def targetImageName = "kato-x8664-timestamp-centos"
+      def targetImageName = "kato"
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_CENTOS_HVM_IMAGE_NAME,
         docker_target_image: targetImageName,
+        docker_target_image_tag: SOME_MILLISECONDS,
         docker_target_repository: TARGET_REPOSITORY,
         repository: YUM_REPOSITORY,
         package_type: RPM_PACKAGE_TYPE.packageType,
@@ -247,8 +250,8 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -258,7 +261,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
       def fullyQualifiedPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
-      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      def imageTag = "nflx-djangobase-enhanced"
       def buildHost = "http://some-build-server:8080"
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: fullyQualifiedPackageName,
@@ -266,16 +269,16 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         build_host: buildHost,
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def osPackage = PackageNameConverter.parseDebPackageName(bakeRequest.package_name)
-      def targetImageName = "kato-x8664-timestamp-trusty"
+      def targetImageName = "kato"
       def parameterMap = [
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
+        docker_target_image_tag: imageTag,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir,
-        appversion: appVersionStr,
         build_host: buildHost
       ]
 
@@ -290,9 +293,58 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, [osPackage]) >> imageTag
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+  }
+
+  void 'produces packer command with all required parameters including docker specific parameters'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def fullyQualifiedPackageName = "trojan-banker_0.1-h12.170cdbd_all"
+      def targetImageName = "trojan-banker"
+      def targetOrganization = "ECorp"
+      def targetImageTag = "extended"
+      def targetQualifiedImageName = "${targetOrganization}/${targetImageName}"
+      def bakeRequest = new BakeRequest(
+        package_name: "trojan-banker_0.1-3_all",
+        build_number: "12",
+        commit_hash: "170cdbd",
+        base_os: "ubuntu",
+        cloud_provider_type: BakeRequest.CloudProviderType.docker,
+        extended_attributes: [
+          docker_target_image_name: targetImageName,
+          docker_target_image_tag: targetImageTag,
+          docker_target_organization: targetOrganization
+        ]
+      )
+      def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
+      def parameterMap = [
+        docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        docker_target_image: targetQualifiedImageName,
+        docker_target_image_tag: targetImageTag,
+        docker_target_repository: TARGET_REPOSITORY,
+        repository: DEBIAN_REPOSITORY,
+        package_type: DEB_PACKAGE_TYPE.packageType,
+        packages: fullyQualifiedPackageName,
+        configDir: configDir,
+        docker_target_image_name: targetImageName,
+        docker_target_organization: targetOrganization,
+      ]
+      @Subject
+      DockerBakeHandler dockerBakeHandler = new DockerBakeHandler(configDir: configDir,
+        dockerBakeryDefaults: dockerBakeryDefaults,
+        imageNameFactory: imageNameFactoryMock,
+        packerCommandFactory: packerCommandFactoryMock,
+        debianRepository: DEBIAN_REPOSITORY)
+    when:
+      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+    then:
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetQualifiedImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> targetImageTag
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorSpec.groovy
@@ -1,0 +1,50 @@
+package com.netflix.spinnaker.rosco.providers.docker
+
+import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+
+class DockerImageNameFactorSpec extends Specification implements TestDefaults {
+  void "Should build imageName and imageTag without specific docker attributes"() {
+    setup:
+      def imageNameFactory = new DockerImageNameFactory()
+      def bakeRequest = new BakeRequest(
+        package_name: "nflx-djangobase-enhanced_0.1-3_all",
+        build_number: "12",
+        commit_hash: "170cdbd",
+        base_os: "ubuntu")
+      def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
+    when:
+      String imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      String imageTag = imageNameFactory.buildImageTag(bakeRequest, osPackages)
+      def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
+    then:
+      imageName == "nflx-djangobase-enhanced"
+      imageTag == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
+      packagesParameter == "nflx-djangobase-enhanced=0.1-3"
+  }
+
+  void "Should build imageName with specific docker attribute"() {
+    setup:
+      def imageNameFactory = new DockerImageNameFactory()
+      def bakeRequest = new BakeRequest(
+        package_name: "trojan-banker_0.1-3_all",
+        build_number: "12",
+        commit_hash: "170cdbd",
+        base_os: "ubuntu",
+        extended_attributes: [
+          docker_target_image_name: "trojan-banker",
+          docker_target_organization: "ECorp"
+        ]
+      )
+      def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
+    when:
+      String imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      String imageTag = imageNameFactory.buildImageTag(bakeRequest, osPackages)
+      def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
+    then:
+      imageName == "ECorp/trojan-banker"
+      imageTag == "trojan-banker-0.1-h12.170cdbd"
+      packagesParameter == "trojan-banker=0.1-3"
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -183,8 +183,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -223,8 +223,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -264,8 +264,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -305,8 +305,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
   }
@@ -348,8 +348,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -389,8 +389,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -429,8 +429,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -475,8 +475,8 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, [osPackage]) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -526,7 +526,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       gceBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
 
       IllegalArgumentException e = thrown()
       e.message == "No Google account specified for bakery."

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
@@ -288,8 +288,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -345,8 +345,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
     openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-    1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-    1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> appVersionStr
+    1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+    1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> appVersionStr
     1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
     1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -395,8 +395,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -446,8 +446,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$template_file_name")
   }
@@ -498,8 +498,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -548,8 +548,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -599,8 +599,8 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
       openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
 
     then:
-      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildImageTag(bakeRequest, osPackages) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactorySpec.groovy
@@ -34,8 +34,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name) 
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -55,8 +55,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -76,8 +76,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -97,8 +97,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -119,8 +119,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -140,8 +140,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
     def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -163,8 +163,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -185,8 +185,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -207,8 +207,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -228,8 +228,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -251,8 +251,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -273,8 +273,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -295,8 +295,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -315,8 +315,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -334,8 +334,8 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
 
     when:
-      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def imageName = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildImageTag(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -9,6 +9,7 @@ trait TestDefaults {
   static final String YUM_REPOSITORY = "http://some-yum-repository"
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
+  static final String SOME_MILLISECONDS = "1470391070464"
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))


### PR DESCRIPTION
The thought here was to simply enable more relevant naming conventions for docker images. This took a bit more time than expected because I ended up fighting with the use of the extended_attributes. Now I'm at a point where I need some feedback to nail this. 

The problem, as I see it, is that the way that extended_attributes are currently handled we end up with a situation where the client of the Rosco API has to know how Rosco is implemented to not get in the way of it's job. 
In addition the CloudProvider-specific BakeHandler has to use a different extended_attribute name than the one being sent to packer in the ```parameterMap```. For instance I wanted to use ``` docker_target_image ``` as an extended attribute, which I would adapt to the naming convention in ``` DockeImageNameFactory ``` and then pass along to packer via the ``` parameterMap ```. However that was not possible due to the last instruction in ```CloudProviderBakeHandler.producePackerCommand``` which adds all extended_attributes to the parameterMap, and in effect overwriting anything which was previously there, except for ```share_with``` and ```copy_to``` which are handled manually. From my perspective the main problems with the current solution is that we end up with  'extra' attributes to avoid name collisions, and that you can't trust that entries in the ``` parameterMap ``` will not be overwritten. 

I ended up with the compromise where the CloudProvider-specific BakeHandles can choose which attributes are 'overridable' and promote those attributes in their ``` buildParameterMap``` method, using the ``` promoteExtendedAttributes ``` helper. This way overrides are  explicitly made possible, and extended_attributes which are not already present in the ``` parametrMap ``` are all added in ``` CloudProviderBakeHandler ``` like before.


Sorry for the wall of text. Wdyt?