### PR TITLE
Adding docker specific naming conventions

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -59,6 +59,8 @@ class BakeRequest {
   String ami_suffix
   Boolean upgrade
   String instance_type
+  @ApiModelProperty("The image owner organization")
+  String organization
 
   @ApiModelProperty("The explicit packer template to use, instead of resolving one from rosco's configuration")
   String template_file_name

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -91,7 +91,7 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def awsVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def awsVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
     def parameterMap = [
       aws_region       : region,
       aws_ssh_username : awsVirtualizationSettings.sshUserName,
@@ -123,6 +123,10 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
 
     if (bakeRequest.build_info_url) {
       parameterMap.build_info_url = bakeRequest.build_info_url
+    }
+
+    if (appVersionStr) {
+      parameterMap.appversion = appVersionStr
     }
 
     return parameterMap

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -80,7 +80,7 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
   }
 
   @Override
-  Map buildParameterMap(String region, Object virtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def virtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
 
     def selectedImage = azureBakeryDefaults?.baseImages?.find { it.baseImage.id == bakeRequest.base_os }
 
@@ -100,6 +100,10 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
       azure_image_sku: selectedImage?.baseImage?.sku,
       azure_image_name: "$bakeRequest.build_number-$bakeRequest.base_name"
     ]
+
+    if (appVersionStr) {
+      parameterMap.appversion = appVersionStr
+    }
 
     return parameterMap
   }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -31,7 +31,7 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
   private static final String BUILDER_TYPE = "docker"
   private static final String IMAGE_NAME_TOKEN = "Repository:"
 
-  ImageNameFactory imageNameFactory = new ImageNameFactory()
+  ImageNameFactory imageNameFactory = new DockerImageNameFactory()
 
   @Autowired
   RoscoDockerConfiguration.DockerBakeryDefaults dockerBakeryDefaults
@@ -67,12 +67,14 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
     return [
       docker_source_image     : dockerVirtualizationSettings.sourceImage,
       docker_target_image     : imageName,
+      docker_target_image_tag : appVersionStr,
       docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
+
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.rosco.providers.docker
+
+import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
+import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+
+class DockerImageNameFactory extends ImageNameFactory {
+
+  @Override
+  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+    super.buildAppVersionStr(bakeRequest, osPackageNames) ?: clock.millis().toString()
+  }
+
+  @Override
+  def buildImageName(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+
+    String imageName = bakeRequest.ami_name ?: osPackageNames.first()?.name
+    String imageNamePrefixed = [bakeRequest.organization, imageName].findAll({it}).join("/")
+    String imageNameSuffixed = [imageNamePrefixed, bakeRequest.ami_suffix].findAll({it}).join("-")
+
+    return imageNameSuffixed
+  }
+
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -71,7 +71,7 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def gceVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def gceVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
     RoscoGoogleConfiguration.ManagedGoogleAccount managedGoogleAccount = googleConfigurationProperties?.accounts?.getAt(0)
 
     if (!managedGoogleAccount) {
@@ -92,6 +92,10 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
 
     if (gceBakeryDefaults.useInternalIp != null) {
       parameterMap.gce_use_internal_ip = gceBakeryDefaults.useInternalIp
+    }
+
+    if (appVersionStr) {
+      parameterMap.appversion = appVersionStr
     }
 
     return parameterMap

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandler.groovy
@@ -86,7 +86,7 @@ public class OpenstackBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  Map buildParameterMap(String region, def openstackVirtualizationSettings, String imageName, BakeRequest bakeRequest) {
+  Map buildParameterMap(String region, def openstackVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
     def parameterMap = [
       openstack_identity_endpoint: openstackBakeryDefaults.identityEndpoint,
       openstack_region: region,
@@ -123,6 +123,10 @@ public class OpenstackBakeHandler extends CloudProviderBakeHandler {
 
     if (bakeRequest.build_info_url) {
       parameterMap.build_info_url = bakeRequest.build_info_url
+    }
+
+    if (appVersionStr) {
+      parameterMap.appversion = appVersionStr
     }
 
     return parameterMap

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
@@ -1,0 +1,69 @@
+package com.netflix.spinnaker.rosco.providers.docker
+
+import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+
+import java.time.Clock
+
+class DockerImageNameFactorySpec extends Specification implements TestDefaults {
+
+  void "Should provide a docker image name based on package_name and organization"() {
+    setup:
+      def clockMock = Mock(Clock)
+      def imageNameFactory = new DockerImageNameFactory(clock: clockMock)
+      def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced-0.1-3.all kato redis-server",
+        build_number: "12",
+        commit_hash: "170cdbd",
+        organization: "ECorp",
+        base_os: "centos")
+      def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
+    when:
+      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
+    then:
+      imageName == "ECorp/nflx-djangobase-enhanced"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
+      packagesParameter == "nflx-djangobase-enhanced-0.1-3 kato redis-server"
+  }
+
+  void "Should provide a docker image name based on ami_name, ami_suffix and no organization"() {
+    setup:
+      def clockMock = Mock(Clock)
+      def imageNameFactory = new DockerImageNameFactory(clock: clockMock)
+      def bakeRequest = new BakeRequest(package_name: "nflx-djangobase-enhanced-0.1-3.all kato redis-server",
+        build_number: "12",
+        commit_hash: "170cdbd",
+        ami_name: "superimage",
+        ami_suffix: "ultimate",
+        base_os: "centos")
+      def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
+    when:
+      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
+    then:
+      imageName == "superimage-ultimate"
+      appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
+      packagesParameter == "nflx-djangobase-enhanced-0.1-3 kato redis-server"
+  }
+
+  void "Should provide a docker image name and tag with minimal parameters in the BakeRequest"() {
+    setup:
+      def clockMock = Mock(Clock)
+      def imageNameFactory = new DockerImageNameFactory(clock: clockMock)
+      def bakeRequest = new BakeRequest(package_name: "superimage kato redis-server",
+        base_os: "centos")
+      def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
+    when:
+      def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
+    then:
+      clockMock.millis() >> SOME_MILLISECONDS.toLong()
+      imageName == "superimage"
+      appVersionStr == SOME_MILLISECONDS
+      packagesParameter == "superimage kato redis-server"
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -9,6 +9,7 @@ trait TestDefaults {
   static final String YUM_REPOSITORY = "http://some-yum-repository"
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
+  static final String SOME_MILLISECONDS = "1470391070464"
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))


### PR DESCRIPTION
The thought here is to let ``` organization ``` become a full member of the bakeRequest, and let it, ``` ami_name ``` and ``` ami_suffix ``` provide the default basis for the ``` docker_target_image ```. 

We discussed (@duftler) letting the docker specific parameters like the docker image name come into the BakeRequest, but in retrospect it seems to me that re-using the ami_name/ami_suffix names, (and rather refactoring those some time in the future) would make more sense and keep the ``` BakeRequest ``` as uncluttered as possible. And I'm suggesting that organization might be general enough to be usefull for other providers, but this might be wrong? I think both ways work, so feel free to mix it up.  This PR will ofc also require a PR in Orca before the ``` organization ```  field can be utilised, which means we could also enrich that field which might be in line with what @lwander suggested earlier with regards to naming conventions and docker/kubernetes. FWIW I tried making this as simple as possible so these things can come step by step. 