### PR TITLE
Install packer in docker for rosco (cloned from rush)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,16 @@ RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test
 
 RUN dpkg -i ./rosco-web/build/distributions/*.deb
 
+RUN mkdir /packer
+
+WORKDIR /packer
+
+RUN wget https://releases.hashicorp.com/packer/0.10.0/packer_0.10.0_linux_amd64.zip
+
+RUN apt-get install unzip -y
+
+RUN unzip packer_0.10.0_linux_amd64.zip
+
+ENV PATH "/packer:$PATH"
+
 CMD ["/opt/rosco/bin/rosco"]


### PR DESCRIPTION
Noticed that packer is running from rosco instead of rush now. I wasn't able to bake ami successfully while  running rosco docker image.  Thus cloning similar change from rush docker to rosco docker. 

(https://github.com/spinnaker/rush/commit/f94712ad5fb2c4ae729c4ab8cc3a620f0903054a#diff-3254677a7917c6c01f55212f86c57fbf)