### PR TITLE
Fix for NPE in BakeryController.runBake due to timing issue

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobExecutor.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobExecutor.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.rosco.api.BakeStatus
 
 interface JobExecutor {
   String startJob(JobRequest jobRequest)
-  BakeStatus getJob(String jobId)
+  boolean jobExists(String jobId)
   BakeStatus updateJob(String jobId)
   void cancelJob(String jobId)
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobExecutor.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobExecutor.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.rosco.api.BakeStatus
 
 interface JobExecutor {
   String startJob(JobRequest jobRequest)
+  BakeStatus getJob(String jobId)
   BakeStatus updateJob(String jobId)
   void cancelJob(String jobId)
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -111,7 +111,7 @@ class JobExecutorLocal implements JobExecutor {
 
   @Override
   boolean jobExists(String jobId) {
-    return jobIdToHandlerMap.containsKey(jobId);
+    return jobIdToHandlerMap.containsKey(jobId)
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -111,6 +111,22 @@ class JobExecutorLocal implements JobExecutor {
   }
 
   @Override
+  BakeStatus getJob(String jobId) {
+    try {
+      if (jobIdToHandlerMap[jobId]) {
+        return new BakeStatus(id: jobId, resource_id: jobId)
+      } else {
+        // This instance of rosco is not managing the job.
+        return null;
+      }
+    } catch (Exception e) {
+      log.error("Failed to get $jobId", e)
+
+      return null
+    }
+  }
+
+  @Override
   BakeStatus updateJob(String jobId) {
     try {
       log.info("Polling state for $jobId...")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -110,19 +110,8 @@ class JobExecutorLocal implements JobExecutor {
   }
 
   @Override
-  BakeStatus getJob(String jobId) {
-    try {
-      if (jobIdToHandlerMap[jobId]) {
-        return new BakeStatus(id: jobId, resource_id: jobId)
-      } else {
-        // This instance of rosco is not managing the job.
-        return null;
-      }
-    } catch (Exception e) {
-      log.error("Failed to get $jobId", e)
-
-      return null
-    }
+  boolean jobExists(String jobId) {
+    return jobIdToHandlerMap.containsKey(jobId);
   }
 
   @Override

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
@@ -98,8 +98,19 @@ class BakeryController {
     String jobId = jobExecutor.startJob(jobRequest)
 
     // Give the job jobExecutor some time to kick off the job.
+    // Poll for bake status by job id every 1/2 second for 5 seconds.
     // The goal here is to fail fast. If it takes too much time, no point in waiting here.
-    sleep(1000)
+    def startTime = System.currentTimeMillis()
+
+    while (System.currentTimeMillis() - startTime < 5000) {
+      def bakeStatus = jobExecutor.getJob(jobId)
+
+      if (bakeStatus) {
+        break;
+      } else {
+        Thread.sleep(500)
+      }
+    }
 
     // Update the status right away so we can fail fast if necessary.
     BakeStatus newBakeStatus = jobExecutor.updateJob(jobId)


### PR DESCRIPTION
BakeryController.runBake starts the job, sleeps for a second and then updates the job

JobExecutor.startJob uses threadpool to run the jobs

If there are multiple bakes from a single jenkins build, some of them fail with NPE because of the timing issue

To fix it, instead of sleeping for 1s, check for job status every 1/2 second for 5 seconds
