### PR TITLE
Adding a uuid for each bake request which is reused when running the …

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -31,6 +31,9 @@ import io.swagger.annotations.ApiModelProperty
 @CompileStatic
 class BakeRequest {
 
+  // A generated uuid which will identify the request and be used as the jobId when running the bake
+  @ApiModelProperty(value = "A generated UUID which will be used to identify the effective packer bake", readOnly = true)
+  final String request_id = UUID.randomUUID().toString()
   String user
   @ApiModelProperty("The package(s) to install") @JsonProperty("package") @SerializedName("package")
   String package_name

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
@@ -27,6 +27,7 @@ import groovy.transform.Immutable
 class JobRequest {
   List<String> tokenizedCommand
   List<String> maskedPackerParameters = []
+  String jobId
 
   List<String> getMaskedTokenizedCommand() {
     return tokenizedCommand.collect { String masked ->

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -48,8 +48,7 @@ class JobExecutorLocal implements JobExecutor {
   @Override
   String startJob(JobRequest jobRequest) {
     log.info("Starting job: $jobRequest.maskedTokenizedCommand...")
-
-    String jobId = UUID.randomUUID().toString()
+    String jobId = jobRequest.jobId
 
     scheduler.createWorker().schedule(
       new Action0() {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -71,7 +71,7 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
     return [
       docker_source_image     : dockerVirtualizationSettings.sourceImage,
       docker_target_image     : imageName,
-      docker_target_image_tag : appVersionStr,
+      docker_target_image_tag : bakeRequest.request_id,
       docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -149,13 +149,14 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
+                                        request_id: SOME_UUID,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-ubuntu"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
         docker_target_image: targetImageName,
-        docker_target_image_tag: SOME_MILLISECONDS,
+        docker_target_image_tag: SOME_UUID,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
@@ -187,13 +188,14 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
                                         base_os: "trusty",
+                                        request_id: SOME_UUID,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
-        docker_target_image_tag: SOME_MILLISECONDS,
+        docker_target_image_tag: SOME_UUID,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
@@ -225,13 +227,14 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
                                         base_os: "centos",
+                                        request_id: SOME_UUID,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-centos"
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
         docker_source_image: SOURCE_CENTOS_HVM_IMAGE_NAME,
         docker_target_image: targetImageName,
-        docker_target_image_tag: SOME_MILLISECONDS,
+        docker_target_image_tag: SOME_UUID,
         docker_target_repository: TARGET_REPOSITORY,
         repository: YUM_REPOSITORY,
         package_type: RPM_PACKAGE_TYPE.packageType,
@@ -266,13 +269,14 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: fullyQualifiedPackageName,
                                         base_os: "trusty",
                                         build_host: buildHost,
+                                        request_id: SOME_UUID,
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def osPackage = PackageNameConverter.parseDebPackageName(bakeRequest.package_name)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def parameterMap = [
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
-        docker_target_image_tag: SOME_MILLISECONDS,
+        docker_target_image_tag: SOME_UUID,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,
@@ -309,6 +313,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def targetQualifiedImageName = "${targetOrganization}/${targetImageName}"
 
       def bakeRequest = new BakeRequest(
+        request_id: SOME_UUID,
         package_name: "trojan-banker_0.1-3_all",
         build_number: "12",
         commit_hash: "170cdbd",
@@ -321,7 +326,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       def parameterMap = [
         docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
         docker_target_image: targetQualifiedImageName,
-        docker_target_image_tag: targetImageTag,
+        docker_target_image_tag: SOME_UUID,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.packageType,

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -10,6 +10,7 @@ trait TestDefaults {
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
   static final String SOME_MILLISECONDS = "1470391070464"
+  static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
@@ -161,7 +161,7 @@ class BakeryController {
       }
 
       def packerCommand = cloudProviderBakeHandler.producePackerCommand(region, bakeRequest)
-      def jobRequest = new JobRequest(tokenizedCommand: packerCommand, maskedPackerParameters: cloudProviderBakeHandler.maskedPackerParameters)
+      def jobRequest = new JobRequest(tokenizedCommand: packerCommand, maskedPackerParameters: cloudProviderBakeHandler.maskedPackerParameters, jobId: bakeRequest.request_id)
 
       if (bakeStore.acquireBakeLock(bakeKey)) {
         return runBake(bakeKey, region, bakeRequest, jobRequest)

--- a/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
+++ b/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
@@ -42,6 +42,7 @@ class BakeryControllerSpec extends Specification {
   private static final String BAKE_ID = "some-bake-id"
   private static final String PACKER_COMMAND = "packer build ..."
   private static final String LOGS_CONTENT = "Some logs content..."
+  private static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
 
   void 'create bake launches job and returns new status'() {
     setup:
@@ -52,7 +53,8 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
       def runningBakeStatus = new BakeStatus(id: JOB_ID, resource_id: JOB_ID, state: BakeStatus.State.RUNNING)
 
       @Subject
@@ -69,7 +71,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.retrieveBakeStatusByKey(BAKE_KEY) >> null
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> runningBakeStatus
       1 * bakeStoreMock.storeNewBakeStatus(BAKE_KEY, REGION, bakeRequest, runningBakeStatus, PACKER_COMMAND) >> runningBakeStatus
       returnedBakeStatus == runningBakeStatus
@@ -84,7 +86,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def failedBakeStatus = new BakeStatus(id: JOB_ID,
                                             resource_id: JOB_ID,
                                             state: BakeStatus.State.CANCELED,
@@ -105,7 +109,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.retrieveBakeStatusByKey(BAKE_KEY) >> null
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> failedBakeStatus
       IllegalArgumentException e = thrown()
       e.message == "Some kind of failure..."
@@ -149,7 +153,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def runningBakeStatus = new BakeStatus(id: JOB_ID, resource_id: JOB_ID, state: BakeStatus.State.RUNNING)
 
       @Subject
@@ -168,7 +174,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> false
       (10.._) * bakeStoreMock.retrieveBakeStatusByKey(BAKE_KEY) >> null
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> runningBakeStatus
       1 * bakeStoreMock.storeNewBakeStatus(BAKE_KEY, REGION, bakeRequest, runningBakeStatus, PACKER_COMMAND) >> runningBakeStatus
       returnedBakeStatus == new BakeStatus(id: JOB_ID, resource_id: JOB_ID, state: BakeStatus.State.RUNNING)
@@ -182,9 +188,11 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
 
-    @Subject
+
+      @Subject
       def bakeryController = new BakeryController(cloudProviderBakeHandlerRegistry: cloudProviderBakeHandlerRegistryMock,
                                                   bakeStore: bakeStoreMock)
 
@@ -209,7 +217,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
 
       @Subject
       def bakeryController = new BakeryController(cloudProviderBakeHandlerRegistry: cloudProviderBakeHandlerRegistryMock)
@@ -231,7 +241,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def runningBakeStatus = new BakeStatus(id: EXISTING_JOB_ID,
                                              resource_id: EXISTING_JOB_ID,
                                              state: BakeStatus.State.RUNNING)
@@ -259,7 +271,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def completedBakeStatus = new BakeStatus(id: EXISTING_JOB_ID,
                                                resource_id: EXISTING_JOB_ID,
                                                state: BakeStatus.State.COMPLETED,
@@ -289,7 +303,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def failedBakeStatus = new BakeStatus(id: EXISTING_JOB_ID,
                                             resource_id: EXISTING_JOB_ID,
                                             state: BakeStatus.State.CANCELED,
@@ -310,7 +326,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.retrieveBakeStatusByKey(BAKE_KEY) >> failedBakeStatus
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> newBakeStatus
       1 * bakeStoreMock.storeNewBakeStatus(BAKE_KEY, REGION, bakeRequest, newBakeStatus, PACKER_COMMAND) >> newBakeStatus
       returnedBakeStatus == newBakeStatus
@@ -325,7 +341,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def canceledBakeStatus = new BakeStatus(id: EXISTING_JOB_ID,
                                               resource_id: EXISTING_JOB_ID,
                                               state: BakeStatus.State.CANCELED)
@@ -345,7 +363,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.retrieveBakeStatusByKey(BAKE_KEY) >> canceledBakeStatus
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> newBakeStatus
       1 * bakeStoreMock.storeNewBakeStatus(BAKE_KEY, REGION, bakeRequest, newBakeStatus, PACKER_COMMAND) >> newBakeStatus
       returnedBakeStatus == newBakeStatus
@@ -360,7 +378,9 @@ class BakeryControllerSpec extends Specification {
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
                                         base_os: "ubuntu",
-                                        cloud_provider_type: BakeRequest.CloudProviderType.gce)
+                                        cloud_provider_type: BakeRequest.CloudProviderType.gce,
+                                        request_id: SOME_UUID)
+
       def newBakeStatus = new BakeStatus(id: JOB_ID, resource_id: JOB_ID, state: BakeStatus.State.RUNNING)
 
       @Subject
@@ -378,7 +398,7 @@ class BakeryControllerSpec extends Specification {
       1 * bakeStoreMock.deleteBakeByKeyPreserveDetails(BAKE_KEY) >> BAKE_ID
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
-      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
+      1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND], jobId: SOME_UUID)) >> JOB_ID
       1 * jobExecutorMock.updateJob(JOB_ID) >> newBakeStatus
       1 * bakeStoreMock.storeNewBakeStatus(BAKE_KEY, REGION, bakeRequest, newBakeStatus, PACKER_COMMAND) >> newBakeStatus
       returnedBakeStatus == newBakeStatus


### PR DESCRIPTION
…packer job. I'm also using this uuid when setting the docker tag so that we can trace a docker image back to a build. A later PR will extend the attributes returned when querying a bake result. 

The current naming conventions which uses the AppVersionStr broke whenever a slash was included in the tag, and this is a solution for that. 