### PR TITLE
Add new deleteBakeByKeyPreserveDetails() BakeStore entry-point and em…

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
@@ -79,9 +79,17 @@ interface BakeStore {
 
   /**
    * Delete the bake status, completed bake details and logs associated with the bakeKey. If the bake is still
-   * incomplete, remove the bake id from the set of incomplete bakes.
+   * incomplete, remove the bake id from the set of incomplete bakes. Returns the bake id of the deleted bake or null
+   * if it is not found.
    */
-  public boolean deleteBakeByKey(String bakeKey)
+  public String deleteBakeByKey(String bakeKey)
+
+  /**
+   * Delete the bake status associated with the bake key. If the bake is still incomplete, remove the bake id from the
+   * set of incomplete bakes and mark the bake CANCELED. Leave behind any completed bake details and logs associated
+   * with the bake id resolved from the bake key. Returns the bake id of the deleted bake or null if it is not found.
+   */
+  public String deleteBakeByKeyPreserveDetails(String bakeKey)
 
   /**
    * Cancel the incomplete bake associated with the bake id and delete the completed bake details associated with the

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
@@ -50,6 +50,8 @@ class RedisBackedBakeStore implements BakeStore {
 
     jedis.withCloseable {
       scriptNameToSHAMap.with {
+        // Expected key list: lock key, bake key
+        // Expected arg list: ttlMilliseconds
         acquireBakeLockSHA = jedis.scriptLoad("""\
           -- Set the lock key key if it's not already set.
           if redis.call('SETNX', KEYS[1], 'locked') == 1 then
@@ -66,6 +68,8 @@ class RedisBackedBakeStore implements BakeStore {
             return false
           end
         """)
+        // Expected key list: "allBakes", bake id, bake key, this instance incomplete bakes key, lock key
+        // Expected arg list: createdTimestampMilliseconds, region, bake request json, bake status json, bake logs json, command, rosco instance id
         storeNewBakeStatusSHA = jedis.scriptLoad("""\
           -- Delete the bake id key.
           redis.call('DEL', KEYS[2])
@@ -108,11 +112,13 @@ class RedisBackedBakeStore implements BakeStore {
           -- Delete the lock key key instead of just allowing it to wait out the TTL.
           redis.call('DEL', KEYS[5])
         """)
+        // Expected key list: bake id
+        // Expected arg list: bake details json
         updateBakeDetailsSHA = jedis.scriptLoad("""\
           local existing_bake_status = redis.call('HGET', KEYS[1], 'bakeStatus')
 
           -- Ensure we don't update/resurrect a canceled bake (can happen due to a race).
-          if existing_bake_status and cjson.decode(existing_bake_status)["state"] == "CANCELED" then
+          if existing_bake_status and cjson.decode(existing_bake_status)['state'] == '$BakeStatus.State.CANCELED' then
             return
           end
 
@@ -125,11 +131,13 @@ class RedisBackedBakeStore implements BakeStore {
           -- Update the bake details set on the bake key hash.
           redis.call('HSET', bake_key, 'bakeDetails', ARGV[1])
         """)
+        // Expected key list: bake id, this instance incomplete bakes key
+        // Expected arg list: bake status json, bake logs json, updatedTimestampMilliseconds
         def updateBakeStatusBaseScript = """\
           local existing_bake_status = redis.call('HGET', KEYS[1], 'bakeStatus')
 
           -- Ensure we don't update/resurrect a canceled bake (can happen due to a race).
-          if existing_bake_status and cjson.decode(existing_bake_status)["state"] == "CANCELED" then
+          if existing_bake_status and cjson.decode(existing_bake_status)['state'] == '$BakeStatus.State.CANCELED' then
             return
           end
 
@@ -151,11 +159,15 @@ class RedisBackedBakeStore implements BakeStore {
           end
         """
         updateBakeStatusSHA = jedis.scriptLoad(updateBakeStatusBaseScript)
+        // Expected key list: bake id, this instance incomplete bakes key
+        // Expected arg list: bake status json, bake logs json, updatedTimestampMilliseconds
         def updateBakeStatusWithIncompleteRemovalScript = updateBakeStatusBaseScript + """\
           -- Remove bake id from set of incomplete bakes.
           redis.call('SREM', KEYS[2], KEYS[1])
         """
         updateBakeStatusWithIncompleteRemovalSHA = jedis.scriptLoad(updateBakeStatusWithIncompleteRemovalScript)
+        // Expected key list: bake id
+        // Expected arg list: error
         storeBakeErrorSHA = jedis.scriptLoad("""\
           -- Retrieve the bake key associated with bake id.
           local bake_key = redis.call('HGET', KEYS[1], 'bakeKey')
@@ -168,6 +180,8 @@ class RedisBackedBakeStore implements BakeStore {
             redis.call('HSET', bake_key, 'bakeError', ARGV[1])
           end
         """)
+        // Expected key list: bake key, "allBakes", incomplete bake keys...
+        // Expected arg list:
         deleteBakeByKeySHA = jedis.scriptLoad("""\
           -- Retrieve the bake id associated with bake key.
           local bake_id = redis.call('HGET', KEYS[1], 'id')
@@ -193,6 +207,8 @@ class RedisBackedBakeStore implements BakeStore {
 
           return bake_id
         """)
+        // Expected key list: bake key, "allBakes", incomplete bake keys...
+        // Expected arg list: updatedTimestampMilliseconds
         deleteBakeByKeyPreserveDetailsSHA = jedis.scriptLoad("""\
           -- Retrieve the bake id associated with bake key.
           local bake_id = redis.call('HGET', KEYS[1], 'id')
@@ -218,9 +234,9 @@ class RedisBackedBakeStore implements BakeStore {
             if bake_status then
               local bake_status_json = cjson.decode(bake_status)
 
-              if bake_status_json['state'] == 'RUNNING' then
-                bake_status_json['state'] = 'CANCELED'
-                bake_status_json['result'] = 'FAILURE'
+              if bake_status_json['state'] == '$BakeStatus.State.RUNNING' then
+                bake_status_json['state'] = '$BakeStatus.State.CANCELED'
+                bake_status_json['result'] = '$BakeStatus.Result.FAILURE'
 
                 -- Update the bake status set on the bake id hash.
                  redis.call('HMSET', bake_id,
@@ -232,6 +248,8 @@ class RedisBackedBakeStore implements BakeStore {
 
           return bake_id
         """)
+        // Expected key list: bake id, "allBakes", incomplete bake keys...
+        // Expected arg list: bake status json, updatedTimestampMilliseconds
         cancelBakeByIdSHA = jedis.scriptLoad("""
           -- Retrieve the bake key associated with bake id.
           local bake_key = redis.call('HGET', KEYS[1], 'bakeKey')

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
@@ -176,17 +176,61 @@ class RedisBackedBakeStore implements BakeStore {
           redis.call('ZREM', KEYS[2], KEYS[1])
 
           -- Delete the bake key key.
-          local ret = redis.call('DEL', KEYS[1])
+          redis.call('DEL', KEYS[1])
 
           if bake_id then
-            -- Remove the bake id from the set of incomplete bakes.
-            redis.call('SREM', KEYS[3], bake_id)
+            -- Retrieve the rosco instance id associated with bake id.
+            local rosco_instance_id = redis.call('HGET', bake_id, 'roscoInstanceId')
+
+            if rosco_instance_id then
+              -- Remove bake id from that rosco instance's set of incomplete bakes.
+              redis.call('SREM', 'allBakes:incomplete:' .. rosco_instance_id, bake_id)
+            end
 
             -- Delete the bake id key.
             redis.call('DEL', bake_id)
           end
 
-          return ret
+          return bake_id
+        """)
+        deleteBakeByKeyPreserveDetailsSHA = jedis.scriptLoad("""\
+          -- Retrieve the bake id associated with bake key.
+          local bake_id = redis.call('HGET', KEYS[1], 'id')
+
+          -- Remove bake key from the set of bakes.
+          redis.call('ZREM', KEYS[2], KEYS[1])
+
+          -- Delete the bake key key.
+          redis.call('DEL', KEYS[1])
+
+          if bake_id then
+            -- Retrieve the rosco instance id associated with bake id.
+            local rosco_instance_id = redis.call('HGET', bake_id, 'roscoInstanceId')
+
+            if rosco_instance_id then
+              -- Remove bake id from that rosco instance's set of incomplete bakes.
+              redis.call('SREM', 'allBakes:incomplete:' .. rosco_instance_id, bake_id)
+            end
+
+            -- Set bake state to CANCELED if still running.
+            local bake_status = redis.call('HGET', bake_id, 'bakeStatus')
+
+            if bake_status then
+              local bake_status_json = cjson.decode(bake_status)
+
+              if bake_status_json['state'] == 'RUNNING' then
+                bake_status_json['state'] = 'CANCELED'
+                bake_status_json['result'] = 'FAILURE'
+
+                -- Update the bake status set on the bake id hash.
+                 redis.call('HMSET', bake_id,
+                            'bakeStatus', cjson.encode(bake_status_json),
+                            'updatedTimestamp', ARGV[1])
+              end
+            end
+          end
+
+          return bake_id
         """)
         cancelBakeByIdSHA = jedis.scriptLoad("""
           -- Retrieve the bake key associated with bake id.
@@ -355,10 +399,34 @@ class RedisBackedBakeStore implements BakeStore {
   }
 
   @Override
-  public boolean deleteBakeByKey(String bakeKey) {
-    def keyList = [bakeKey, "allBakes", thisInstanceIncompleteBakesKey]
+  public String deleteBakeByKey(String bakeKey) {
+    def jedis = jedisPool.getResource()
+    def keyList = [bakeKey, "allBakes"]
 
-    return evalSHA("deleteBakeByKeySHA", keyList, []) == 1
+    jedis.withCloseable {
+      Set<String> incompleteBakesKeys = jedis.keys(allIncompleteBakesKeyPattern)
+
+      keyList += incompleteBakesKeys
+    }
+
+    return evalSHA("deleteBakeByKeySHA", keyList, [])
+  }
+
+  @Override
+  public String deleteBakeByKeyPreserveDetails(String bakeKey) {
+    def jedis = jedisPool.getResource()
+    def updatedTimestampMilliseconds = timeInMilliseconds
+    def keyList = [bakeKey, "allBakes"]
+
+    jedis.withCloseable {
+      Set<String> incompleteBakesKeys = jedis.keys(allIncompleteBakesKeyPattern)
+
+      keyList += incompleteBakesKeys
+    }
+
+    def argList = [updatedTimestampMilliseconds + ""]
+
+    return evalSHA("deleteBakeByKeyPreserveDetailsSHA", keyList, argList)
   }
 
   @Override
@@ -367,8 +435,8 @@ class RedisBackedBakeStore implements BakeStore {
                                     resource_id: bakeId,
                                     state: BakeStatus.State.CANCELED,
                                     result: BakeStatus.Result.FAILURE)
-    def jedis = jedisPool.getResource()
     def bakeStatusJson = mapper.writeValueAsString(bakeStatus)
+    def jedis = jedisPool.getResource()
     def updatedTimestampMilliseconds = timeInMilliseconds
     def keyList = [bakeId, "allBakes"]
 

--- a/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
+++ b/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
@@ -39,6 +39,7 @@ class BakeryControllerSpec extends Specification {
   private static final String AMI_ID = "ami-3cf4a854"
   private static final String IMAGE_NAME = "some-image"
   private static final String BAKE_KEY = "bake:gce:ubuntu:$PACKAGE_NAME"
+  private static final String BAKE_ID = "some-bake-id"
   private static final String PACKER_COMMAND = "packer build ..."
   private static final String LOGS_CONTENT = "Some logs content..."
 
@@ -374,7 +375,7 @@ class BakeryControllerSpec extends Specification {
     then:
       1 * cloudProviderBakeHandlerRegistryMock.lookup(BakeRequest.CloudProviderType.gce) >> cloudProviderBakeHandlerMock
       1 * cloudProviderBakeHandlerMock.produceBakeKey(REGION, bakeRequest) >> BAKE_KEY
-      1 * bakeStoreMock.deleteBakeByKey(BAKE_KEY)
+      1 * bakeStoreMock.deleteBakeByKeyPreserveDetails(BAKE_KEY) >> BAKE_ID
       1 * cloudProviderBakeHandlerMock.producePackerCommand(REGION, bakeRequest) >> [PACKER_COMMAND]
       1 * bakeStoreMock.acquireBakeLock(BAKE_KEY) >> true
       1 * jobExecutorMock.startJob(new JobRequest(tokenizedCommand: [PACKER_COMMAND])) >> JOB_ID
@@ -526,8 +527,8 @@ class BakeryControllerSpec extends Specification {
     then:
       1 * cloudProviderBakeHandlerRegistryMock.lookup(BakeRequest.CloudProviderType.gce) >> cloudProviderBakeHandlerMock
       1 * cloudProviderBakeHandlerMock.produceBakeKey(REGION, bakeRequest) >> BAKE_KEY
-      1 * bakeStoreMock.deleteBakeByKey(BAKE_KEY) >> true
-      response == "Deleted bake '$BAKE_KEY'."
+      1 * bakeStoreMock.deleteBakeByKey(BAKE_KEY) >> BAKE_ID
+      response == "Deleted bake '$BAKE_KEY' with id '$BAKE_ID'."
   }
 
   void 'delete bake throws exception when bake key cannot be found'() {
@@ -550,7 +551,7 @@ class BakeryControllerSpec extends Specification {
     then:
       1 * cloudProviderBakeHandlerRegistryMock.lookup(BakeRequest.CloudProviderType.gce) >> cloudProviderBakeHandlerMock
       1 * cloudProviderBakeHandlerMock.produceBakeKey(REGION, bakeRequest) >> BAKE_KEY
-      1 * bakeStoreMock.deleteBakeByKey(BAKE_KEY) >> false
+      1 * bakeStoreMock.deleteBakeByKey(BAKE_KEY) >> null
       IllegalArgumentException e = thrown()
       e.message == "Unable to locate bake with key '$BAKE_KEY'."
   }


### PR DESCRIPTION
…ploy it when rebaking. This allows older bakes that have been rebaked to retain their logs and other details.
Modify deleteBakeByKey() to return the bake id of a deleted bake and include this in the response message.
Modify RedisBackedBakeStore.deleteBakeByKey() to resolve the appropriate rosco instance id instead of assuming the bake is being rebaked on the same rosco instance.
Modify BakeryController.createBake() to also cancel the executor's bake job when performing a rebake.