### PR TITLE
Add instance status endpoint

### DIFF
--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -273,3 +273,4 @@ swagger:
   patterns:
     - /api/v1.*
     - /bakeOptions.*
+    - /status.*

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -41,6 +41,7 @@ import javax.servlet.Filter
 @ComponentScan([
   "com.netflix.spinnaker.rosco.config",
   "com.netflix.spinnaker.rosco.controllers",
+  "com.netflix.spinnaker.rosco.endpoints",
   "com.netflix.spinnaker.rosco.executor",
   "com.netflix.spinnaker.rosco.filters",
   "com.netflix.spinnaker.rosco.jobs",

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/AllStatusEndpoint.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/AllStatusEndpoint.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+@ConfigurationProperties(prefix = "endpoints.status", ignoreUnknownFields = false)
+class AllStatusEndpoint extends AbstractEndpoint<Map<String, Object>> {
+
+  private final StatusHandler statusHandler
+
+  @Autowired
+  AllStatusEndpoint(StatusHandler statusHandler) {
+    super("status", false, true)
+    this.statusHandler = statusHandler
+  }
+
+  @Override
+  public Map<String, Object> invoke() {
+    return statusHandler.AllIncompleteBakes()
+  }
+}

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/InstanceStatusEndpoint.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/InstanceStatusEndpoint.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+
+@Component
+@Slf4j
+@ConfigurationProperties(prefix = "endpoints.status", ignoreUnknownFields = false)
+class InstanceStatusEndpoint extends AbstractEndpoint<Map<String, Object>> {
+
+  private final StatusHandler statusHandler
+
+  @Autowired
+  InstanceStatusEndpoint(StatusHandler statusHandler) {
+    super("status", false, true)
+    this.statusHandler = statusHandler
+  }
+
+  @Override
+  public Map<String, Object> invoke() {
+    return statusHandler.instanceIncompleteBakes()
+  }
+
+}

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/StatusHandler.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/StatusHandler.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints
+
+import com.netflix.spinnaker.rosco.api.BakeStatus
+import com.netflix.spinnaker.rosco.persistence.BakeStore
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class StatusHandler {
+
+  private final BakeStore bakeStore
+  private final String roscoInstanceId
+
+  private static enum Status {
+    RUNNING, IDLE
+  }
+
+  @Autowired
+  StatusHandler(BakeStore bakeStore, String roscoInstanceId) {
+    this.bakeStore = bakeStore
+    this.roscoInstanceId = roscoInstanceId
+  }
+
+  public Map<String, Object> instanceIncompleteBakes() {
+    def instanceIncompleteBakeIds = bakeStore.getThisInstanceIncompleteBakeIds()
+    return getBakesAndInstanceStatus(instanceIncompleteBakeIds)
+  }
+
+  public Map<String, Object> AllIncompleteBakes() {
+    def instances = [:]
+    def allIncompleteBakeIds = bakeStore.getAllIncompleteBakeIds()
+    if (allIncompleteBakeIds) {
+      for (instanceEntry in allIncompleteBakeIds.entrySet()) {
+        instances[instanceEntry.key] = getBakesAndInstanceStatus(instanceEntry.value)
+      }
+    }
+    return Collections.unmodifiableMap(["instance": roscoInstanceId, "instances": instances])
+  }
+
+  private Map<String, Object> getBakesAndInstanceStatus(Set<String> instanceIncompleteBakeIds) {
+    def instanceStatus, bakes
+    if (instanceIncompleteBakeIds) {
+      instanceStatus = Status.RUNNING
+      bakes = getBakes(instanceIncompleteBakeIds)
+    } else {
+      instanceStatus = Status.IDLE
+      bakes = []
+    }
+    return Collections.unmodifiableMap(["status": instanceStatus.name(), "bakes": bakes])
+  }
+
+  private List<BakeStatus> getBakes(instanceIncompleteBakeIds) {
+    def status = []
+    for (bakeId in instanceIncompleteBakeIds) {
+      def bakeStatus = bakeStore.retrieveBakeStatusById(bakeId)
+      if (bakeStatus) {
+        status << bakeStatus
+      }
+    }
+    return status
+  }
+
+}

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/mvc/AllStatusMvcEndpoint.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/mvc/AllStatusMvcEndpoint.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints.mvc
+
+import com.netflix.spinnaker.rosco.endpoints.AllStatusEndpoint
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Component
+class AllStatusMvcEndpoint extends EndpointMvcAdapter {
+
+  @Autowired
+  public AllStatusMvcEndpoint(AllStatusEndpoint delegate) {
+    super(delegate)
+  }
+
+  @RequestMapping(value = '/all', method = RequestMethod.GET)
+  @ResponseBody
+  @Override
+  public Object invoke() {
+    if (!getDelegate().isEnabled()) {
+      return new ResponseEntity<Map<String, String>>(Collections.singletonMap(
+          "message", "This endpoint is disabled"), HttpStatus.NOT_FOUND)
+    }
+    return super.invoke()
+  }
+}

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/mvc/InstanceStatusMvcEndpoint.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/endpoints/mvc/InstanceStatusMvcEndpoint.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints.mvc
+
+import com.netflix.spinnaker.rosco.endpoints.InstanceStatusEndpoint
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Component
+class InstanceStatusMvcEndpoint extends EndpointMvcAdapter {
+
+  @Autowired
+  public InstanceStatusMvcEndpoint(InstanceStatusEndpoint delegate) {
+    super(delegate)
+  }
+
+  @RequestMapping(value = '/instance', method = RequestMethod.GET)
+  @ResponseBody
+  @Override
+  public Object invoke() {
+    if (!getDelegate().isEnabled()) {
+      return new ResponseEntity<Map<String, String>>(Collections.singletonMap(
+          "message", "This endpoint is disabled"), HttpStatus.NOT_FOUND)
+    }
+    return super.invoke()
+  }
+}

--- a/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/endpoints/AllStatusEndpointSpec.groovy
+++ b/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/endpoints/AllStatusEndpointSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints
+
+import com.google.common.collect.Sets
+import com.netflix.spinnaker.rosco.api.BakeStatus
+import com.netflix.spinnaker.rosco.persistence.RedisBackedBakeStore
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AllStatusEndpointSpec extends Specification {
+
+  private static final String LOCAL_JOB_ID = "123"
+  private static final String REMOTE_JOB_ID = "123"
+  private static localRunningBakeStatus = new BakeStatus(id: LOCAL_JOB_ID, resource_id: LOCAL_JOB_ID, state: BakeStatus.State.RUNNING, result: null)
+  private static remoteRunningBakeStatus = new BakeStatus(id: REMOTE_JOB_ID, resource_id: REMOTE_JOB_ID, state: BakeStatus.State.RUNNING, result: null)
+  private static String localInstanceId = UUID.randomUUID().toString()
+  private static String remoteInstanceId = UUID.randomUUID().toString()
+
+  void 'all instances incomplete bakes with status'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    def statusHandler = new StatusHandler(bakeStoreMock, localInstanceId)
+
+    @Subject
+    def statusEndpoint = new AllStatusEndpoint(statusHandler)
+
+    when:
+    def instances = statusEndpoint.invoke()
+    then:
+    1 * bakeStoreMock.getAllIncompleteBakeIds() >> [(localInstanceId): Sets.newHashSet(LOCAL_JOB_ID), (remoteInstanceId): Sets.newHashSet(REMOTE_JOB_ID)]
+    1 * bakeStoreMock.retrieveBakeStatusById(LOCAL_JOB_ID) >> localRunningBakeStatus
+    1 * bakeStoreMock.retrieveBakeStatusById(REMOTE_JOB_ID) >> remoteRunningBakeStatus
+    instances == [instance: localInstanceId, instances: [(localInstanceId): [status: "RUNNING", bakes: [localRunningBakeStatus]], (remoteInstanceId): [status: "RUNNING", bakes: [remoteRunningBakeStatus]]]]
+  }
+
+  void 'all instances incomplete bakes without status'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getAllIncompleteBakeIds() >> new HashMap<String, Set<String>>()
+    def statusHandler = new StatusHandler(bakeStoreMock, localInstanceId)
+
+    @Subject
+    def statusEndpoint = new AllStatusEndpoint(statusHandler)
+
+    when:
+    def instances = statusEndpoint.invoke()
+
+    then:
+    1 * bakeStoreMock.getAllIncompleteBakeIds()
+    instances == [instance: localInstanceId, instances: [:]]
+  }
+
+  void 'no instances incomplete bakes'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    def statusHandler = new StatusHandler(bakeStoreMock, localInstanceId)
+
+    @Subject
+    def statusEndpoint = new AllStatusEndpoint(statusHandler)
+
+    when:
+    def instances = statusEndpoint.invoke()
+
+    then:
+    instances == [instance: localInstanceId, instances: [:]]
+  }
+
+  void 'redis exception on get incomplete bakes'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getAllIncompleteBakeIds() >> { throw new RuntimeException() }
+    def statusHandler = new StatusHandler(bakeStoreMock, localInstanceId)
+
+    @Subject
+    def statusEndpoint = new AllStatusEndpoint(statusHandler)
+
+    when:
+    statusEndpoint.invoke()
+
+    then:
+    thrown(RuntimeException)
+  }
+
+  void 'redis exception on get bakes result'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getAllIncompleteBakeIds() >> [(localInstanceId): Sets.newHashSet(LOCAL_JOB_ID), (remoteInstanceId): Sets.newHashSet(REMOTE_JOB_ID)]
+    bakeStoreMock.retrieveBakeStatusById(LOCAL_JOB_ID) >> { throw new RuntimeException() }
+    bakeStoreMock.retrieveBakeStatusById(REMOTE_JOB_ID) >> { throw new RuntimeException() }
+    def statusHandler = new StatusHandler(bakeStoreMock, localInstanceId)
+
+    @Subject
+    def statusEndpoint = new AllStatusEndpoint(statusHandler)
+
+    when:
+    statusEndpoint.invoke()
+
+    then:
+    thrown(RuntimeException)
+  }
+
+}

--- a/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/endpoints/InstanceStatusEndpointSpec.groovy
+++ b/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/endpoints/InstanceStatusEndpointSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.endpoints
+
+import com.google.common.collect.Sets
+import com.netflix.spinnaker.rosco.api.BakeStatus
+import com.netflix.spinnaker.rosco.persistence.RedisBackedBakeStore
+import spock.lang.Specification
+import spock.lang.Subject
+
+class InstanceStatusEndpointSpec extends Specification {
+
+  private static final String JOB_ID = "123"
+  private
+  static runningBakeStatus = new BakeStatus(id: JOB_ID, resource_id: JOB_ID, state: BakeStatus.State.RUNNING, result: null)
+  private static String instanceId = UUID.randomUUID().toString()
+
+  void 'instance incomplete bakes with status'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    def statusHandler = new StatusHandler(bakeStoreMock, instanceId)
+
+    @Subject
+    def statusEndpoint = new InstanceStatusEndpoint(statusHandler)
+
+    when:
+    def instanceInfo = statusEndpoint.invoke()
+
+    then:
+    1 * bakeStoreMock.getThisInstanceIncompleteBakeIds() >> Sets.newHashSet(JOB_ID)
+    1 * bakeStoreMock.retrieveBakeStatusById(JOB_ID) >> runningBakeStatus
+    instanceInfo.bakes == [runningBakeStatus]
+    instanceInfo.status == "RUNNING"
+  }
+
+  void 'instance incomplete bakes without status'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getThisInstanceIncompleteBakeIds() >> new HashSet<>()
+    def statusHandler = new StatusHandler(bakeStoreMock, instanceId)
+
+    @Subject
+    def statusEndpoint = new InstanceStatusEndpoint(statusHandler)
+
+    when:
+    def instanceInfo = statusEndpoint.invoke()
+
+    then:
+    1 * bakeStoreMock.getThisInstanceIncompleteBakeIds()
+    instanceInfo.bakes.isEmpty()
+    instanceInfo.status == "IDLE"
+  }
+
+  void 'no instance incomplete bakes'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    def statusHandler = new StatusHandler(bakeStoreMock, instanceId)
+
+    @Subject
+    def statusEndpoint = new InstanceStatusEndpoint(statusHandler)
+
+    when:
+    def instanceInfo = statusEndpoint.invoke()
+
+    then:
+    instanceInfo.bakes.isEmpty()
+    instanceInfo.status == "IDLE"
+  }
+
+  void 'redis exception on get incomplete bakes'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getThisInstanceIncompleteBakeIds() >> { throw new RuntimeException() }
+    def statusHandler = new StatusHandler(bakeStoreMock, instanceId)
+
+    @Subject
+    def statusEndpoint = new InstanceStatusEndpoint(statusHandler)
+
+    when:
+    statusEndpoint.invoke()
+
+    then:
+    thrown(RuntimeException)
+  }
+
+  void 'redis exception on get bakes result'() {
+    setup:
+    def bakeStoreMock = Mock(RedisBackedBakeStore)
+    bakeStoreMock.getThisInstanceIncompleteBakeIds() >> Sets.newHashSet(JOB_ID)
+    bakeStoreMock.retrieveBakeStatusById(JOB_ID) >> { throw new RuntimeException() }
+    def statusHandler = new StatusHandler(bakeStoreMock, instanceId)
+
+    @Subject
+    def statusEndpoint = new InstanceStatusEndpoint(statusHandler)
+
+    when:
+    statusEndpoint.invoke()
+
+    then:
+    thrown(RuntimeException)
+  }
+
+}


### PR DESCRIPTION
Adding two instance status endpoints in order to check running bakes.
Both are enabled by default

To disable they add to rosco-local.yml
endpoint.status.enable : true

To enable sensitive flag add to rosco-local.yml
endpoint.status.sensitive : false

**/status/all**
```
{  
   "instance":"a74e6995-ab43-40e2-9b40-cc6afe01e048",
   "instances":{  
      "a74e6995-ab43-40e2-9b40-cc6afe01e048":{  
         "status":"RUNNING",
         "bakes":[  
            {  
               "id":"a459c99e-3ee1-41a0-a45d-de48b0fb2e70",
               "state":"RUNNING",
               "result":null,
               "resource_id":"a459c99e-3ee1-41a0-a45d-de48b0fb2e70"
            }
         ]
      },
      "4e51032e-a114-11e6-80f5-76304dec7eb7":{  
         "status":"RUNNING",
         "bakes":[  
            {  
               "id":"6442a7c8-a114-11e6-80f5-76304dec7eb7",
               "state":"RUNNING",
               "result":null,
               "resource_id":"6442a7c8-a114-11e6-80f5-76304dec7eb7"
            }
         ]
      }
   }
}
```

**/status/instance**
It returns a json with the following format
```
{  
   "status":"RUNNING",
   "bakes":[  
      {  
         "id":"d26cb40c-8758-4ff6-a330-c8cd5c8afe94",
         "state":"RUNNING",
         "result":null,
         "resource_id":"d26cb40c-8758-4ff6-a330-c8cd5c8afe94"
      },
      {  
         "id":"89433795-3ddf-4417-a654-e76a47e8e938",
         "state":"RUNNING",
         "result":null,
         "resource_id":"89433795-3ddf-4417-a654-e76a47e8e938"
      }
   ]
}
```

or in the case the instance is not baking anything
```
{  
   "status":"IDLE",
   "bakes":[ ]
}
```