### PR TITLE
fix name of Azure packer-specific storage account config property. 

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -91,7 +91,7 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
       azure_client_id: selectedAccount?.clientId,
       azure_client_secret: selectedAccount?.appKey,
       azure_resource_group: selectedAccount?.packerResourceGroup,
-      azure_storage_account: selectedAccount?.storageAccount,
+      azure_storage_account: selectedAccount?.packerStorageAccount,
       azure_subscription_id: selectedAccount?.subscriptionId,
       azure_tenant_id: selectedAccount?.tenantId,
       azure_location: region,

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/config/RoscoAzureConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/config/RoscoAzureConfiguration.groovy
@@ -85,6 +85,6 @@ class RoscoAzureConfiguration {
     String tenantId
     String subscriptionId
     String packerResourceGroup
-    String storageAccount
+    String packerStorageAccount
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -94,7 +94,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
           tenantId: TENANT_ID,
           subscriptionId: SUBSCRIPTION_ID,
           packerResourceGroup: RESOURCE_GROUP,
-          storageAccount: STORAGE_ACCOUNT
+          packerStorageAccount: STORAGE_ACCOUNT
         ]
       ]
     ]

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -3,6 +3,9 @@ server:
 
 rosco:
   configDir: /some/path/to/config/packer
+  jobs:
+    local:
+      timeoutMinutes: 20
 
 metrics:
   reporter:


### PR DESCRIPTION
Also bump the timeout for rosco since Azure packer consistently exceeds the 10 minute default timeout.