### PR TITLE
RFC: Extend the bake endpoint with build info

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Artifact.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Artifact.groovy
@@ -1,0 +1,12 @@
+package com.netflix.spinnaker.rosco.api
+
+/**
+ * The details of the baked artifact
+ *
+ * @see Bake
+ */
+class Artifact {
+  String name
+  String reference
+  String type
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Bake.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Bake.groovy
@@ -32,6 +32,10 @@ import io.swagger.annotations.ApiModelProperty
 class Bake {
   @ApiModelProperty(value="The id of the bake job.")
   String id
-  String ami
-  String image_name
+  @Deprecated
+  String ami // Replaced by Artifact.name
+  @Deprecated
+  String image_name // Replaced by Artifact.reference
+  Artifact artifact // The artifact produced by the bake
+  BuildInfo build_info // The build responsible for the content of this bake
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BuildInfo.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BuildInfo.groovy
@@ -1,0 +1,14 @@
+package com.netflix.spinnaker.rosco.api
+
+/**
+ * The details of a specific build
+ *
+ * @see Bake
+ */
+class BuildInfo {
+  String url
+  String host
+  String job_name
+  String job_number
+  String organisation
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
@@ -63,6 +63,11 @@ interface BakeStore {
   public BakeStatus retrieveBakeStatusByKey(String bakeKey)
 
   /**
+   * Retrieve the bake request associated with the bakeKey. bakeKey may be null.
+   */
+  public BakeRequest retrieveBakeRequestById(String bakeId)
+
+  /**
    * Retrieve the bake status associated with the bakeId. bakeId may be null.
    */
   public BakeStatus retrieveBakeStatusById(String bakeId)

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/RedisBackedBakeStore.groovy
@@ -364,6 +364,16 @@ class RedisBackedBakeStore implements BakeStore {
   }
 
   @Override
+  public BakeRequest retrieveBakeRequestById(String bakeId) {
+    def jedis = jedisPool.getResource()
+
+    jedis.withCloseable {
+      def bakeRequestJson = jedis.hget(bakeId, "bakeRequest")
+      return bakeRequestJson ? mapper.readValue(bakeRequestJson, BakeRequest) : null
+    }
+  }
+
+  @Override
   public BakeStatus retrieveBakeStatusByKey(String bakeKey) {
     def jedis = jedisPool.getResource()
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco.executor
 
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.rosco.api.Bake
+import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.api.BakeStatus
 import com.netflix.spinnaker.rosco.persistence.RedisBackedBakeStore
 import com.netflix.spinnaker.rosco.providers.CloudProviderBakeHandler
@@ -46,7 +47,6 @@ class BakePollerSpec extends Specification {
                                                 state: bakeState,
                                                 result: bakeResult,
                                                 logsContent: LOGS_CONTENT)
-
       @Subject
       def bakePoller = new BakePoller(bakeStore: bakeStoreMock,
                                       executor: jobExecutorMock,
@@ -86,6 +86,8 @@ class BakePollerSpec extends Specification {
                                       cloudProviderBakeHandlerRegistry: cloudProviderBakeHandlerRegistryMock,
                                       registry: new DefaultRegistry())
 
+      def bakeRequest = new BakeRequest(build_number: 42, cloud_provider_type: BakeRequest.CloudProviderType.aws)
+
     when:
       bakePoller.updateBakeStatusAndLogs(JOB_ID)
 
@@ -97,6 +99,7 @@ class BakePollerSpec extends Specification {
       1 * bakeStoreMock.updateBakeDetails(bakeDetails)
       1 * bakeStoreMock.updateBakeStatus(completeBakeStatus)
       1 * bakeStoreMock.retrieveBakeStatusById(JOB_ID) >> completeBakeStatus
+      1 * bakeStoreMock.retrieveBakeRequestById(JOB_ID) >> bakeRequest
 
     where:
       bakeState                  | bakeResult


### PR DESCRIPTION
The rationale behind this PR is twofold;

1. We recently changed the defafult docker tag of baked images to be the bake id (#139), this PR will now allow us to ask rosco about a bake and get the build info based only on the docker tag. The alternative would be to find a way to incorporate this as metadata in the docker image, but this would mean we would have to find ways of doing this for all new cloud providers down the road. This PR instead relies on Rosco as a source of truth for this information. (Redis as a cache vs persistent storage might be an interesting topic here. )

2. Gard presented his ideas on general Artifacts last week, and it seemed to be an acceptance of the idea although more discussion might be needed for the actual implementation. But in this case it seemed logical to adapt to this general idea of an artifact when I had to change the return value of the bake endpoint anyway. So thoughts on that is also appreciated. 

This PR is first and foremost for discussion as we might want sturdier tests. It would also be worth a discussion wether the Artifact version should be a part of the Artifact object in the /bake endpoint. The /bake endpoint now returns something like this:

```
{
  "id" : "613bc102-9dad-42c3-bef2-c3ff4e484bb4",
  "ami" : null,
  "image_name" : "containers.schibsted.io/spt-infrastructure/mybuild:613bc102-9dad-42c3-bef2-c3ff4e484bb4",
  "artifact" : {
    "name" : null,
    "reference" : "containers.schibsted.io/spt-infrastructure/mybuild:613bc102-9dad-42c3-bef2-c3ff4e484bb4",
    "type" : "docker"
  },
  "build_info" : {
    "url" : null,
    "host" : "travis.schibsted.io",
    "job_name" : "jira-cli",
    "job_number" : 42,
    "organisation" : "spt-infrastructure"
  }
}
```

Which will let us get to the build info for docker images baked in Rosco which is currently not possible AFAIK. And it would probably also be helpfull to other providers.