### PR TITLE
Adding build and package metadata to baked docker image

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -68,12 +68,22 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
 
   @Override
   Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
-    return [
+    def parameterMap = [
       docker_source_image     : dockerVirtualizationSettings.sourceImage,
       docker_target_image     : imageName,
       docker_target_image_tag : bakeRequest.request_id,
       docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
+
+    if (bakeRequest.build_info_url) {
+      parameterMap.build_info_url = bakeRequest.build_info_url
+    }
+
+    if (appVersionStr) {
+      parameterMap.appversion = appVersionStr
+    }
+
+    return parameterMap
 
   }
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -150,10 +150,13 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "ubuntu",
                                         request_id: SOME_UUID,
+                                        build_info_url: SOME_BUILD_INFO_URL,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-ubuntu"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
+        appversion: SOME_MILLISECONDS,
+        build_info_url: SOME_BUILD_INFO_URL,
         docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
         docker_target_image: targetImageName,
         docker_target_image_tag: SOME_UUID,
@@ -189,10 +192,13 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "trusty",
                                         request_id: SOME_UUID,
+                                        build_info_url: SOME_BUILD_INFO_URL,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
+        appversion: SOME_MILLISECONDS,
+        build_info_url: SOME_BUILD_INFO_URL,
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
         docker_target_image_tag: SOME_UUID,
@@ -228,10 +234,13 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: PACKAGES_NAME,
                                         base_os: "centos",
                                         request_id: SOME_UUID,
+                                        build_info_url: SOME_BUILD_INFO_URL,
                                         cloud_provider_type: BakeRequest.CloudProviderType.docker)
       def targetImageName = "kato-x8664-timestamp-centos"
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
+        appversion: SOME_MILLISECONDS,
+        build_info_url: SOME_BUILD_INFO_URL,
         docker_source_image: SOURCE_CENTOS_HVM_IMAGE_NAME,
         docker_target_image: targetImageName,
         docker_target_image_tag: SOME_UUID,
@@ -269,11 +278,14 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         package_name: fullyQualifiedPackageName,
                                         base_os: "trusty",
                                         build_host: buildHost,
+                                        build_info_url: SOME_BUILD_INFO_URL,
                                         request_id: SOME_UUID,
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
       def osPackage = PackageNameConverter.parseDebPackageName(bakeRequest.package_name)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def parameterMap = [
+        appversion: SOME_MILLISECONDS,
+        build_info_url: SOME_BUILD_INFO_URL,
         docker_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         docker_target_image: targetImageName,
         docker_target_image_tag: SOME_UUID,
@@ -318,12 +330,15 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         build_number: "12",
         commit_hash: "170cdbd",
         organization: targetOrganization,
+        build_info_url: SOME_BUILD_INFO_URL,
         ami_name: targetImageName,
         base_os: "ubuntu",
         cloud_provider_type: BakeRequest.CloudProviderType.docker
       )
       def osPackages = parseDebOsPackageNames(bakeRequest.package_name)
       def parameterMap = [
+        appversion: targetImageTag,
+        build_info_url: SOME_BUILD_INFO_URL,
         docker_source_image: SOURCE_UBUNTU_IMAGE_NAME,
         docker_target_image: targetQualifiedImageName,
         docker_target_image_tag: SOME_UUID,

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -11,6 +11,7 @@ trait TestDefaults {
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
   static final String SOME_MILLISECONDS = "1470391070464"
   static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
+  static final String SOME_BUILD_INFO_URL = "http://some-build-server:8080/repogroup/repo/builds/320282"
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))

--- a/rosco-web/config/packer/docker.json
+++ b/rosco-web/config/packer/docker.json
@@ -4,6 +4,8 @@
     "docker_target_image": null,
     "docker_target_image_tag": "latest",
     "docker_target_repository": null,
+    "appversion": "",
+    "build_info_url": "",
     "repository": "",
     "package_type": "",
     "packages": "",
@@ -12,7 +14,11 @@
   "builders": [{
     "type": "docker",
     "image": "{{user `docker_source_image`}}",
-    "export_path": "image.tar"
+    "commit": true,
+    "run_command": ["-d", "-i", "-t",
+      "--label", "appversion={{user `appversion`}}",
+      "--label", "build_info_url={{user `build_info_url`}}",
+      "{{.Image}}", "/bin/bash"]
   }],
   "provisioners": [{
     "type": "shell",
@@ -21,12 +27,11 @@
       "repository={{user `repository`}}",
       "package_type={{user `package_type`}}",
       "packages={{user `packages`}}"
-    ],
-    "pause_before": "30s"
+    ]
   }],
   "post-processors": [[
     {
-      "type": "docker-import",
+      "type": "docker-tag",
       "repository": "{{user `docker_target_repository`}}/{{user `docker_target_image`}}",
       "tag": "{{user `docker_target_image_tag`}}"
     },


### PR DESCRIPTION
This will let docker images replicate the behavior used with AMIs so that we can have the appversion and build url attached to the docker image. 