### PR TITLE
Removing ami_suffix from docker image name

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
@@ -16,9 +16,8 @@ class DockerImageNameFactory extends ImageNameFactory {
 
     String imageName = bakeRequest.ami_name ?: osPackageNames.first()?.name
     String imageNamePrefixed = [bakeRequest.organization, imageName].findAll({it}).join("/")
-    String imageNameSuffixed = [imageNamePrefixed, bakeRequest.ami_suffix].findAll({it}).join("-")
 
-    return imageNameSuffixed
+    return imageNamePrefixed
   }
 
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
@@ -28,7 +28,7 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       packagesParameter == "nflx-djangobase-enhanced-0.1-3 kato redis-server"
   }
 
-  void "Should provide a docker image name based on ami_name, ami_suffix and no organization"() {
+  void "Should provide a docker image name based on ami_name and no organization"() {
     setup:
       def clockMock = Mock(Clock)
       def imageNameFactory = new DockerImageNameFactory(clock: clockMock)
@@ -36,7 +36,6 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
         build_number: "12",
         commit_hash: "170cdbd",
         ami_name: "superimage",
-        ami_suffix: "ultimate",
         base_os: "centos")
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
     when:
@@ -44,7 +43,7 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
     then:
-      imageName == "superimage-ultimate"
+      imageName == "superimage"
       appVersionStr == "nflx-djangobase-enhanced-0.1-h12.170cdbd"
       packagesParameter == "nflx-djangobase-enhanced-0.1-3 kato redis-server"
   }


### PR DESCRIPTION
I had misunderstood the use of ami_suffix. And it seems unnatural to add it to the docker image name. For docker images I'm thinking that multiple tags / labels would be a better approach if we need such a qualifier. 