### PR TITLE
Pass templateName to getBaseCommand to determine whether sudo is required

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -116,9 +116,9 @@ abstract class CloudProviderBakeHandler {
   /**
    * Returns the command that should be prepended to the shell command passed to the container.
    */
-  String getBaseCommand() {
+  String getBaseCommand(String templateName) {
     if (templatesNeedingRoot) {
-      return templatesNeedingRoot.contains(getBakeryDefaults().templateFile) ? "sudo" : ""
+      return templatesNeedingRoot.contains(templateName) ? "sudo" : ""
     } else {
       return ""
     }
@@ -179,13 +179,15 @@ abstract class CloudProviderBakeHandler {
       }
     }
 
-    def finalTemplateFileName = "$configDir/${bakeRequest.template_file_name ?: templateFileName}"
+    def finalTemplateFileName = bakeRequest.template_file_name ?: templateFileName
+    def finaltemplateFilePath = "$configDir/$finalTemplateFileName"
     def finalVarFileName = bakeRequest.var_file_name ? "$configDir/$bakeRequest.var_file_name" : null
+    def baseCommand = getBaseCommand(finalTemplateFileName)
 
     return packerCommandFactory.buildPackerCommand(baseCommand,
                                                    parameterMap,
                                                    finalVarFileName,
-                                                   finalTemplateFileName)
+                                                   finaltemplateFilePath)
   }
 
   protected Map unrollParameters(Map.Entry entry) {


### PR DESCRIPTION
In our rosco setup, we bake with some templates that require root and others that do not require root.

Originally, I thought that I would simply be able to define `templatesNeedingRoot: my-template-name.json` and then anytime I bake with that template it would be run with root. This was not the case since only the bakery default templateFile was considered when determining whether `sudo` should be used.

I modified things slightly so that `getBaseCommand` considers the passed in `template_file_name` if it exists. If it does not exist the behaviour remains the same.