### PR TITLE
(AWS/Azure) Add support for Windows using Chocolatey as package manager.

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeOptions.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeOptions.groovy
@@ -29,6 +29,7 @@ class BakeOptions {
     String detailedDescription
     BakeRequest.PackageType packageType
     String templateFile
+    BakeRequest.OsType osType = BakeRequest.OsType.linux
   }
 
   static class Selected {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -85,7 +85,8 @@ class BakeRequest {
 
   static enum PackageType {
     RPM('rpm', '-'),
-    DEB('deb', '=')
+    DEB('deb', '='),
+    NUPKG('nupkg', '.')
 
     private final String packageType
     private final String versionDelimiter
@@ -110,6 +111,10 @@ class BakeRequest {
 
   static enum StoreType {
     ebs, s3, docker
+  }
+
+  static enum OsType {
+    linux, windows
   }
 }
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -40,6 +40,9 @@ abstract class CloudProviderBakeHandler {
   @Value('${yumRepository:}')
   String yumRepository
 
+  @Value('${chocolateyRepository:}')
+  String chocolateyRepository
+
   @Value('${templatesNeedingRoot:}')
   List<String> templatesNeedingRoot
 
@@ -142,7 +145,7 @@ abstract class CloudProviderBakeHandler {
 
     def osPackageNames = PackageNameConverter.buildOsPackageNames(packageType, packageNameList)
 
-    def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackageNames)
+    def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackageNames, packageType)
 
     def imageName = imageNameFactory.buildImageName(bakeRequest, osPackageNames)
 
@@ -154,6 +157,8 @@ abstract class CloudProviderBakeHandler {
       parameterMap.repository = debianRepository
     } else if (yumRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.RPM) {
       parameterMap.repository = yumRepository
+    } else if (chocolateyRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.NUPKG) {
+      parameterMap.repository = chocolateyRepository
     }
 
     parameterMap.package_type = selectedOptions.baseImage.packageType.packageType

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -93,11 +93,18 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
   Map buildParameterMap(String region, def awsVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
     def parameterMap = [
       aws_region       : region,
-      aws_ssh_username : awsVirtualizationSettings.sshUserName,
       aws_instance_type: awsVirtualizationSettings.instanceType,
       aws_source_ami   : awsVirtualizationSettings.sourceAmi,
       aws_target_ami   : imageName
     ]
+
+    if (awsVirtualizationSettings.sshUserName) {
+      parameterMap.aws_ssh_username = awsVirtualizationSettings.sshUserName
+    }
+
+    if (awsVirtualizationSettings.winRmUserName) {
+      parameterMap.aws_winrm_username = awsVirtualizationSettings.winRmUserName
+    }
 
     if (awsBakeryDefaults.awsAccessKey && awsBakeryDefaults.awsSecretKey) {
       parameterMap.aws_access_key = awsBakeryDefaults.awsAccessKey

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
@@ -72,6 +72,7 @@ class RoscoAWSConfiguration {
     String instanceType
     String sourceAmi
     String sshUserName
+    String winRmUserName
   }
 
   @PostConstruct

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -88,6 +88,7 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
       azure_storage_account: selectedAccount?.packerStorageAccount,
       azure_subscription_id: selectedAccount?.subscriptionId,
       azure_tenant_id: selectedAccount?.tenantId,
+      azure_object_id: selectedAccount?.objectId,
       azure_location: region,
       azure_image_publisher: selectedImage?.baseImage?.publisher,
       azure_image_offer: selectedImage?.baseImage?.offer,

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/config/RoscoAzureConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/config/RoscoAzureConfiguration.groovy
@@ -61,7 +61,6 @@ class RoscoAzureConfiguration {
     String offer
     String sku
     String version
-    String osType
   }
 
   static class AzureBaseImage {
@@ -84,6 +83,7 @@ class RoscoAzureConfiguration {
     String appKey
     String tenantId
     String subscriptionId
+    String objectId
     String packerResourceGroup
     String packerStorageAccount
   }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
@@ -7,8 +7,8 @@ import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
 class DockerImageNameFactory extends ImageNameFactory {
 
   @Override
-  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
-    super.buildAppVersionStr(bakeRequest, osPackageNames) ?: clock.millis().toString()
+  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames, BakeRequest.PackageType packageType) {
+    super.buildAppVersionStr(bakeRequest, osPackageNames, packageType) ?: clock.millis().toString()
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactory.groovy
@@ -36,11 +36,11 @@ public class ImageNameFactory {
   /**
    * Attempts to produce an appVersionStr from the first packageName; to be used for tagging the newly-baked image
    */
-  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
+  def buildAppVersionStr(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames, BakeRequest.PackageType packageType) {
     String appVersionStr = null
 
     if (osPackageNames) {
-      appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageNames.first())
+      appVersionStr = PackageNameConverter.buildAppVersionStr(bakeRequest, osPackageNames.first(), packageType)
     }
 
     return appVersionStr

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
@@ -26,7 +26,7 @@ class LocalJobFriendlyPackerCommandFactory implements PackerCommandFactory {
     def packerCommand = [baseCommand, "packer", "build", "-color=false"]
     parameterMap.each { key, value ->
       if (key && value) {
-        def keyValuePair = value instanceof String && value.contains(" ") ? "$key=\"$value\"" : "$key=$value"
+        def keyValuePair = "$key=${value instanceof String ? value.trim() : value}"
 
         packerCommand << "-var"
         packerCommand << keyValuePair.toString()

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
@@ -106,12 +106,101 @@ class PackageNameConverter {
     osPackageName
   }
 
+  // Nuget supports SemVer 1.0 for package versioning standards.
+  // Therefore, the naming convention for nuget packages is
+  // {package-name}[.{language}].{major}.{minor}.{patch/build}[-{version}][.{revision}][+{metadata}]
+  // For example: ContosoUtilities.ja-JP.1.0.0-rc1.nupkg
+  //              notepadplusplus.7.3.nupkg
+  //              autohotkey.1.1.24.04.nupkg
+  //              microsoft-aspnet-mvc.6.0.0-rc1-final.nupkg
+  //              microsoft-aspnet-mvc.de.3.0.50813.1.nupkg
+  //              microsoft.aspnet.mvc.6.0.0-rc1-final.nupkg
+  //              microsoft.aspnet.mvc.de.3.0.50813.1.nupkg
+  public static OsPackageName parseNupkgPackageName(String fullyQualifiedPackageName) {
+    OsPackageName osPackageName = new OsPackageName()
+    if (!fullyQualifiedPackageName) return osPackageName
+
+    fullyQualifiedPackageName = fullyQualifiedPackageName.replaceFirst('.nupkg', '')
+
+    osPackageName.with {
+      name = fullyQualifiedPackageName
+
+      List<String> parts = fullyQualifiedPackageName.tokenize(".")
+
+      if (parts.size() > 2) {
+        def versionStart = 0
+
+        for (def i = 0; i < parts.size(); i++) {
+          if (i > 0 && parts[i].isInteger()) {
+            versionStart = i
+            break
+          }
+        }
+
+        if (versionStart < 1) {
+          for (def i = 0; i < parts.size(); i++) {
+            if (i > 0 && parts[i].contains('-') && parts[i][0].isInteger()) {
+              versionStart = i
+              break
+            }
+          }
+        }
+
+        if (versionStart > 0) {
+
+          name = parts.subList(0, versionStart).join('.')
+          version = parts.subList(versionStart, parts.size()).join('.')
+
+          if (version.contains('-')) {
+            (version, release) = version.split('-', 2)
+          } else if (version.contains("+")) {
+            (version, release) = version.split("\\+", 2)
+            release = '+' + release
+          }
+
+        } else {
+
+          def metaDataIndex = parts.findIndexOf { val -> val =~ /\+/ }
+
+          if (metaDataIndex > -1) {
+            (name, release) = parts[metaDataIndex].split('\\+')
+            release = "+" + release
+            name = parts.subList(0, metaDataIndex).join('.') + "." + name
+          } else {
+            name = parts.join('.')
+          }
+        }
+
+      } else if (parts.size() == 2) {
+
+        if (parts[1].isInteger()) {
+          name = parts[0]
+          version = parts[1]
+        } else if (parts[1][0].isInteger() && parts[1].contains('-')) {
+
+            name = parts[0]
+
+            def versionParts = parts[1].split('-', 2)
+            version = versionParts[0]
+            release = versionParts[1]
+
+        } else {
+          name = parts.join(".")
+        }
+      }
+    }
+
+    osPackageName
+  }
+
   public static OsPackageName buildOsPackageName(BakeRequest.PackageType packageType, String packageName) {
     switch (packageType) {
       case BakeRequest.PackageType.DEB:
         return PackageNameConverter.parseDebPackageName(packageName)
       case BakeRequest.PackageType.RPM:
         return PackageNameConverter.parseRpmPackageName(packageName)
+      case BakeRequest.PackageType.NUPKG:
+        return PackageNameConverter.parseNupkgPackageName(packageName)
       default:
         throw new IllegalArgumentException("Unrecognized packageType '$packageType'.")
     }
@@ -123,22 +212,26 @@ class PackageNameConverter {
     }.findAll{it.name}
   }
 
-  public static String buildAppVersionStr(BakeRequest bakeRequest, OsPackageName osPackageName) {
+  public static String buildAppVersionStr(BakeRequest bakeRequest, OsPackageName osPackageName, BakeRequest.PackageType packageType) {
     // As per source of AppVersion, these are valid appversion tags:
     //   subscriberha-1.0.0-h150
     //   subscriberha-1.0.0-h150.586499
     //   subscriberha-1.0.0-h150.586499/WE-WAPP-subscriberha/150
     String appVersion = osPackageName.name
 
+    def versionSeparator = packageType == BakeRequest.PackageType.NUPKG ? "." : "-"
+    def buildNumberSeparator = packageType == BakeRequest.PackageType.NUPKG ? "-" : "-h"
+    def commitHashSeparator = packageType == BakeRequest.PackageType.NUPKG ? "+" : "."
+
     osPackageName.with {
       if (version) {
-        appVersion += "-$version"
+        appVersion += "$versionSeparator$version"
 
         if (bakeRequest.build_number) {
-          appVersion += "-h$bakeRequest.build_number"
+          appVersion += "$buildNumberSeparator$bakeRequest.build_number"
 
           if (bakeRequest.commit_hash) {
-            appVersion += ".$bakeRequest.commit_hash"
+            appVersion += "$commitHashSeparator$bakeRequest.commit_hash"
           }
 
           if (bakeRequest.job) {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -180,7 +180,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> SOME_MILLISECONDS
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -223,7 +223,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> SOME_MILLISECONDS
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -266,7 +266,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> SOME_MILLISECONDS
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -313,7 +313,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> SOME_MILLISECONDS
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage], DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
@@ -361,7 +361,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
     when:
       dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
     then:
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> targetImageTag
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> targetImageTag
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetQualifiedImageName
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
@@ -20,7 +20,7 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
     then:
       imageName == "ECorp/nflx-djangobase-enhanced"
@@ -40,7 +40,7 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
     then:
       imageName == "superimage"
@@ -59,7 +59,7 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
     then:
       clockMock.millis() >> SOME_MILLISECONDS.toLong()

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -226,7 +226,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -266,7 +266,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -307,7 +307,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -348,7 +348,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
   }
@@ -391,7 +391,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -437,7 +437,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -480,7 +480,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -520,7 +520,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -569,7 +569,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage]) >> appVersionStr
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage], DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -611,7 +611,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -651,7 +651,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -692,7 +692,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -732,7 +732,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
@@ -260,7 +260,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -317,7 +317,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-    1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> appVersionStr
+    1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
     1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
     1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -367,7 +367,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -418,7 +418,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$template_file_name")
   }
@@ -470,7 +470,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -520,7 +520,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }
@@ -571,7 +571,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
-      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages) >> null
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$openstackBakeryDefaults.templateFile")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/ImageNameFactorySpec.groovy
@@ -35,7 +35,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -56,7 +56,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -77,7 +77,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -98,7 +98,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -120,7 +120,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -141,7 +141,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -164,7 +164,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -186,7 +186,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -208,7 +208,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -229,7 +229,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages)
 
     then:
@@ -252,7 +252,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -274,7 +274,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -296,7 +296,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -316,7 +316,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:
@@ -335,7 +335,7 @@ class ImageNameFactorySpec extends Specification implements TestDefaults {
 
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
-      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages)
+      def appVersionStr = imageNameFactory.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE)
       def packagesParameter = imageNameFactory.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages)
 
     then:

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
@@ -78,6 +78,73 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
                                                                                               arch: "noarch")
   }
 
+  @Unroll
+  void "nupkg package names are properly parsed"() {
+    when:
+      def osPackageName = PackageNameConverter.parseNupkgPackageName(packageName)
+
+    then:
+      osPackageName == expectedOsPackageName
+
+    where:
+      packageName                                    | expectedOsPackageName
+      null                                           | new PackageNameConverter.OsPackageName()
+      ""                                             | new PackageNameConverter.OsPackageName()
+      "billinggateway.1.0.1"                         | new PackageNameConverter.OsPackageName(name: "billinggateway",
+                                                                                              version: "1.0.1",
+                                                                                              release: null,
+                                                                                              arch: null)
+      "nflx-djangobase-enhanced.1.0.1-rc1"           | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                              version: "1.0.1",
+                                                                                              release: "rc1",
+                                                                                              arch: null)
+      "sf-lucifer.en-US.0.0.10-1"                    | new PackageNameConverter.OsPackageName(name: "sf-lucifer.en-US",
+                                                                                              version: "0.0.10",
+                                                                                              release: "1",
+                                                                                              arch: null)
+      "microsoft.aspnet.mvc"                         | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                              version: null,
+                                                                                              release: null,
+                                                                                              arch: null)
+      "microsoft.aspnet.mvc.6"                       | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                              version: "6",
+                                                                                              release: null,
+                                                                                              arch: null)
+      "microsoft.aspnet.mvc.6-rc1-final"             | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                              version: "6",
+                                                                                              release: "rc1-final",
+                                                                                              arch: null)
+      "microsoft.aspnet.mvc.6.0.0+sf23sdf"           | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                              version: "6.0.0",
+                                                                                              release: "+sf23sdf",
+                                                                                              arch: null)
+      "microsoft.aspnet.mvc.6.0.0-rc1-final+sf23sdf" | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                              version: "6.0.0",
+                                                                                              release: "rc1-final+sf23sdf",
+                                                                                              arch: null)
+      "microsoft-aspnet-mvc"                         | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                              version: null,
+                                                                                              release: null,
+                                                                                              arch: null)
+      "microsoft-aspnet-mvc.6"                       | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                              version: "6",
+                                                                                              release: null,
+                                                                                              arch: null)
+      "microsoft-aspnet-mvc.6-rc1-final"             | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                              version: "6",
+                                                                                              release: "rc1-final",
+                                                                                              arch: null)
+      "microsoft-aspnet-mvc.6.0.0+sf23sdf"           | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                              version: "6.0.0",
+                                                                                              release: "+sf23sdf",
+                                                                                              arch: null)
+      "microsoft-aspnet-mvc.6.0.0-rc1-final+sf23sdf" | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                              version: "6.0.0",
+                                                                                              release: "rc1-final+sf23sdf",
+                                                                                              arch: null)
+
+  }
+
   void "package type is respected when building app version string"() {
     setup:
       def debPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
@@ -91,12 +158,14 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
         new BakeRequest(base_os: "ubuntu",
                         build_number: "12",
                         commit_hash: "170cdbd"),
-        parsedDebPackageName)
+        parsedDebPackageName,
+        DEB_PACKAGE_TYPE)
       def appVersionStrFromRpmPackageName = PackageNameConverter.buildAppVersionStr(
         new BakeRequest(base_os: "centos",
                         build_number: "12",
                         commit_hash: "170cdbd"),
-        parsedRpmPackageName)
+        parsedRpmPackageName,
+        RPM_PACKAGE_TYPE)
 
     then:
       parsedDebPackageName == parsedRpmPackageName
@@ -116,7 +185,7 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
 
     when:
       def parsedDebPackageName = PackageNameConverter.buildOsPackageName(packageType, debPackageName)
-      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName)
+      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName, packageType)
 
     then:
       appVersionStrFromDebPackageName == appVersionStr
@@ -131,7 +200,7 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
 
     when:
       def parsedDebPackageName = PackageNameConverter.buildOsPackageName(packageType, debPackageName)
-      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName)
+      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName, packageType)
 
     then:
       appVersionStrFromDebPackageName == appVersionStr
@@ -148,7 +217,7 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
                                         build_number: "12",
                                         commit_hash: "170cdbd")
       def parsedDebPackageName = PackageNameConverter.buildOsPackageName(packageType, debPackageName)
-      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName)
+      def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(bakeRequest, parsedDebPackageName, packageType)
 
     then:
       appVersionStrFromDebPackageName == appVersionStr

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -5,10 +5,13 @@ import com.netflix.spinnaker.rosco.api.BakeRequest
 trait TestDefaults {
 
   static final String PACKAGES_NAME = "kato nflx-djangobase-enhanced_0.1-h12.170cdbd_all mongodb"
+  static final String NUPKG_PACKAGES_NAME = "googlechrome javaruntime"
   static final String DEBIAN_REPOSITORY = "http://some-debian-repository"
   static final String YUM_REPOSITORY = "http://some-yum-repository"
+  static final String CHOCOLATEY_REPOSITORY = "http://some-chocolatey-repository"
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
+  static final BakeRequest.PackageType NUPKG_PACKAGE_TYPE = BakeRequest.PackageType.NUPKG
   static final String SOME_MILLISECONDS = "1470391070464"
   static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
   static final String SOME_BUILD_INFO_URL = "http://some-build-server:8080/repogroup/repo/builds/320282"
@@ -21,5 +24,9 @@ trait TestDefaults {
 
   def parseRpmOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(RPM_PACKAGE_TYPE, packages.tokenize(" "))
+  }
+
+  def parseNupkgOsPackageNames(String packages) {
+    PackageNameConverter.buildOsPackageNames(NUPKG_PACKAGE_TYPE, packages.tokenize(" "))
   }
 }

--- a/rosco-web/config/packer/aws-windows-2012-r2.json
+++ b/rosco-web/config/packer/aws-windows-2012-r2.json
@@ -1,0 +1,78 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": "",
+    "aws_subnet_id": "{{env `AWS_SUBNET_ID`}}",
+    "aws_vpc_id": "{{env `AWS_VPC_ID`}}",
+    "aws_region": null,
+    "aws_winrm_username": null,
+    "aws_instance_type": null,
+    "aws_source_ami": null,
+    "aws_target_ami": null,
+    "aws_security_group": "",
+    "aws_associate_public_ip_address": "false",
+    "aws_enhanced_networking": "false",
+    "aws_userdata_file": "scripts/aws-windows.userdata",
+    "appversion": "",
+    "build_host": "",
+    "repository": "",
+    "package_type": "",
+    "packages": "",
+    "upgrade": "",
+    "configDir": null
+  },
+
+  "builders": [
+    {
+      "type": "amazon-ebs",
+
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "{{user `aws_winrm_username`}}",
+      "user_data_file": "{{user `configDir`}}/{{user `aws_userdata_file`}}",
+
+      "vpc_id": "{{user `aws_vpc_id`}}",
+
+      "region": "{{user `aws_region`}}",
+
+      "instance_type": "{{user `aws_instance_type`}}",
+
+      "source_ami": "{{user `aws_source_ami`}}",
+
+      "ami_name": "{{user `aws_target_ami` | clean_ami_name}}",
+
+      "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
+
+      "security_group_id": "{{user `aws_security_group`}}",
+
+      "subnet_id": "{{user `aws_subnet_id`}}",
+
+      "tags": {
+        "appversion": "{{user `appversion`}}",
+        "build_host": "{{user `build_host`}}",
+        "build_info_url": "{{user `build_info_url`}}"
+      },
+      "run_tags": {"Packages": "{{user `packages`}}"}
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type":"powershell",
+      "scripts": [
+        "{{user `configDir`}}/scripts/aws-windows-2012-configure-ec2service.ps1",
+        "{{user `configDir`}}/scripts/windows-configure-chocolatey.ps1",
+        "{{user `configDir`}}/scripts/windows-install-packages.ps1"
+      ],
+      "environment_vars": [
+        "repository={{user `repository`}}",
+        "package_type={{user `package_type`}}",
+        "packages={{user `packages`}}",
+        "upgrade={{user `upgrade`}}"
+      ],
+      "pause_before": "30s"
+    }
+  ]
+}

--- a/rosco-web/config/packer/azure-windows-2012-r2.json
+++ b/rosco-web/config/packer/azure-windows-2012-r2.json
@@ -1,0 +1,70 @@
+{
+  "variables": {
+    "azure_client_id": "",
+    "azure_client_secret": "",
+    "azure_resource_group": "",
+    "azure_storage_account": "",
+    "azure_subscription_id": "",
+    "azure_tenant_id": "",
+    "azure_object_id": "",
+    "azure_image_publisher": "",
+    "azure_image_offer": "",
+    "azure_image_sku": "",
+    "azure_location": "",
+    "azure_image_name": "",
+
+    "appversion": "",
+    "build_host": "",
+    "repository": "",
+    "package_type": "",
+    "packages": "",
+    "upgrade": "",
+    "configDir": null
+  },
+  "builders": [{
+    "type": "azure-arm",
+
+    "communicator": "winrm",
+    "winrm_use_ssl": "true",
+    "winrm_insecure": "true",
+    "winrm_timeout": "5m",
+    "winrm_username": "packer",
+
+
+    "client_id": "{{user `azure_client_id`}}",
+    "client_secret": "{{user `azure_client_secret`}}",
+    "resource_group_name": "{{user `azure_resource_group`}}",
+    "storage_account": "{{user `azure_storage_account`}}",
+    "subscription_id": "{{user `azure_subscription_id`}}",
+    "tenant_id": "{{user `azure_tenant_id`}}",
+    "object_id": "{{user `azure_object_id`}}",
+
+    "capture_container_name": "images",
+    "capture_name_prefix": "{{user `azure_image_name`}}",
+
+    "os_type": "Windows",
+    "image_publisher": "{{user `azure_image_publisher`}}",
+    "image_offer": "{{user `azure_image_offer`}}",
+    "image_sku": "{{user `azure_image_sku`}}",
+
+    "location": "{{user `azure_location`}}",
+    "vm_size": "Standard_A2"
+  }],
+
+  "provisioners": [
+    {
+      "type":"powershell",
+      "scripts": [
+        "{{user `configDir`}}/scripts/windows-configure-chocolatey.ps1",
+        "{{user `configDir`}}/scripts/windows-install-packages.ps1"
+      ],
+      "environment_vars": [
+        "repository={{user `repository`}}",
+        "package_type={{user `package_type`}}",
+        "packages={{user `packages`}}",
+        "upgrade={{user `upgrade`}}"
+      ],
+      "pause_before": "30s"
+    }
+  ]
+}

--- a/rosco-web/config/packer/scripts/aws-windows-2012-configure-ec2service.ps1
+++ b/rosco-web/config/packer/scripts/aws-windows-2012-configure-ec2service.ps1
@@ -1,0 +1,42 @@
+# The EC2Config Service configures the EC2 instance at boot time. See the following URL for more details:
+# http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/UsingConfig_WinAMI.html#UsingConfigXML_WinAMI
+
+# Note: The EC2Config Service is not included in Windows Server 2016 AMI's. See the folloing URL for more details:
+# http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/windows-ami-version-history.html#win2k16-amis
+
+# Configure the EC2Config service.
+$ConfigFile="C:\\Program Files\\Amazon\\Ec2ConfigService\\Settings\\Config.xml"
+$xml = [xml](get-content $ConfigFile)
+$xmlElement = $xml.get_DocumentElement()
+$xmlElementToModify = $xmlElement.Plugins
+
+foreach ($element in $xmlElementToModify.Plugin)
+{
+    if ($element.name -eq "Ec2SetPassword")
+    {
+        $element.State="Enabled"
+    }
+    elseif ($element.name -eq "Ec2SetComputerName")
+    {
+        $element.State="Enabled"
+    }
+    elseif ($element.name -eq "Ec2HandleUserData")
+    {
+        $element.State="Enabled"
+    }
+}
+$xml.Save($ConfigFile)
+
+# Configure how EC2Config prepares the instance for AMI creation.
+$BundleConfigFile="C:\\Program Files\\Amazon\\Ec2ConfigService\\Settings\\BundleConfig.xml"
+$xml = [xml](get-content $BundleConfigFile)
+$xmlElement = $xml.get_DocumentElement()
+
+foreach ($element in $xmlElement.Property)
+{
+    if ($element.Name -eq "AutoSysprep")
+    {
+        $element.Value="Yes"
+    }
+}
+$xml.Save($BundleConfigFile)

--- a/rosco-web/config/packer/scripts/aws-windows.userdata
+++ b/rosco-web/config/packer/scripts/aws-windows.userdata
@@ -1,0 +1,30 @@
+<powershell>
+
+# Turn off PowerShell execution policy restrictions.
+$Policy = "Bypass"
+$CurrentExecutionPolicy = (Get-ExecutionPolicy)
+If ($CurrentExecutionPolicy -ne $Policy -OR $CurrentExecutionPolicy -ne "Unrestricted") {
+   Set-ExecutionPolicy $Policy -Scope Process -Force
+}
+
+# Configure WinRM.
+winrm quickconfig -q
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+winrm set winrm/config/winrs '@{MaxConcurrentUsers="100"}'
+winrm set winrm/config/winrs '@{MaxProcessesPerShell="0"}'
+winrm set winrm/config/winrs '@{MaxShellsPerUser="0"}'
+winrm set winrm/config '@{MaxTimeoutms="7200000"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{CredSSP="true"}'
+winrm set winrm/config/client '@{TrustedHosts="*"}'
+
+
+# Open port 5985 in the internal Windows firewall to allow WinRM communication.
+netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
+
+Stop-Service winrm
+Set-Service winrm -startuptype "automatic"
+Start-Service winrm
+
+</powershell>

--- a/rosco-web/config/packer/scripts/windows-configure-chocolatey.ps1
+++ b/rosco-web/config/packer/scripts/windows-configure-chocolatey.ps1
@@ -1,0 +1,85 @@
+
+# Install Chocolatey.
+Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression
+
+# These are the reserved sources that are handled directly by Chocolatey.
+$alternateSources = @("ruby", "webpi", "cygwin", "windowsfeatures", "python")
+
+# Spilt supplied repositories into individual entries.
+[string]$chocolateyRepository = $env:repository
+[string[]]$repositories = @()
+if (![string]::IsNullOrWhiteSpace($chocolateyRepository) -AND $chocolateyRepository -contains ';') {
+    [string[]]$repositories = $chocolateyRepository.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
+} else {
+    $repositories = @($chocolateyRepository)
+}
+
+# Process each repository, adding each one as a package repository.
+$repositoryPriority = 0
+for ($i=0; $i -lt $repositories.Length; $i++) {
+
+    if (![string]::IsNullOrWhiteSpace($repositories[$i])) {
+
+        # Remove leading and trailing whitespaces from the repository URL.
+        $repository = $repositories[$i].Trim()
+
+        if (![string]::IsNullOrWhiteSpace($repository)) {
+
+            $user = $null
+            $pass = $null
+
+            # Ignore repository if it's one of the alternate sources.
+            if ($alternateSources -contains $repository) { continue }
+
+            # Validate the repository URL exists. If status code is not 200 or an exception is
+            # thrown, ignore the repository.
+            $isValid = $false
+            try {
+
+                $repoUri = [System.Uri]$repository
+                $headers = @{}
+                if(![string]::IsNullOrWhiteSpace($repoUri.UserInfo))
+                {
+                    $userpass = $repoUri.UserInfo.Split(":")
+                    $user = $userpass[0]
+                    $pass = $userpass[1]
+                    $repository = $repoUri.AbsoluteUri.Replace($repoUri.UserInfo + "@", "")
+                    $base64 = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${user}:${pass}"))
+                    $headers = @{ Authorization = "Basic $base64" }
+                }
+
+                $statusCode = (Invoke-WebRequest -Uri "$repository" `
+                                                 -UseBasicParsing `
+                                                 -Method GET `
+                                                 -MaximumRedirection 0 `
+                                                 -TimeoutSec 60 `
+                                                 -Headers $headers).StatusCode
+                $isValid = ($statusCode -ge 200 -and $statusCode -lt 300)
+                #Write-Host "Got to here 3:" + $repositories[$i] +"; IsValid: $isValid"
+
+            } catch {
+                $ErrorMessage = $_.Exception.Message
+                $FailedItem = $_.Exception.ItemName
+                Write-Host "Caught exception validating repository ($$repository{}). FailedItem: $FailedItem; ErrorMessage: $ErrorMessage"
+                continue
+            }
+
+            # Ignore repository if URL is invalid.
+            if (!$isValid) { continue }
+
+            # Increment repository priority.
+            $repositoryPriority++
+
+            # Extract the repository name. Use the hostname and domain, coverting the periods to dashes.
+            $repositoryName = (New-Object System.Uri $repository).Host.Replace(".", "-")
+
+            # Add repository to Chocolatey.
+            if(![string]::IsNullOrWhiteSpace($user)){
+                &"choco" source add --yes --name=$repositoryName --source=`"$repository`" --priority=$repositoryPriority --user=$user --password=$pass
+            } else {
+                &"choco" source add --yes --name=$repositoryName --source=`"$repository`" --priority=$repositoryPriority
+            }
+
+        }
+    }
+}

--- a/rosco-web/config/packer/scripts/windows-install-packages.ps1
+++ b/rosco-web/config/packer/scripts/windows-install-packages.ps1
@@ -1,0 +1,13 @@
+$packages = @()
+if (![string]::IsNullOrWhiteSpace($env:packages)) {
+
+    # Split supplied packages into an array.
+    $packages = $env:packages.replace(',', ' ').split(' ')
+
+    # Install packages and enforce installation order.
+    foreach ($package in $packages) {
+        if (![string]::IsNullOrWhiteSpace($package)) {
+            &"choco" install $package --yes
+        }
+    }
+}

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -5,7 +5,7 @@ rosco:
   configDir: /some/path/to/config/packer
   jobs:
     local:
-      timeoutMinutes: 20
+      timeoutMinutes: 30
 
 spectator:
   applicationName: ${spring.application.name}
@@ -15,10 +15,12 @@ spectator:
 # If a repository is set here, it will be added by packer as repository when baking images for GCE and AWS.
 # It is safe to leave this out (or blank) if you do not need to configure your own repository.
 # You can specify an apt repository (used when baking debian based images) and/or a yum repository (used when baking an
-# rpm based imaged)
-# The following commented-out line is an example of what a valid entry looks like.
+# rpm based imaged) and/or a chocolatey repository (used when baking a nuget based image).
+# You may specify a space separated list repositories per repository type.
+# The following commented-out lines are an example of what a valid entry looks like.
 # debianRepository: http://dl.bintray.com/spinnaker/ospackages ./
 # yumRepository: https://https://jfrog.bintray.com/...
+# chocolateyRepository: https://chocolatey.org/api/v2/
 
 defaultCloudProviderType: aws
 
@@ -140,6 +142,20 @@ aws:
         instanceType: m3.medium
         sourceAmi: ami-37501207
         sshUserName: ubuntu
+    - baseImage:
+        id: windows-2012-r2
+        shortDescription: 2012 R2
+        detailedDescription: Windows Server 2012 R2 Base
+        packageType: nupkg
+        templateFile: aws-windows-2012-r2.json
+        osType: windows
+      virtualizationSettings:
+      - region: us-east-1
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-21414f36
+        winRmUserName: Administrator
+
 
 azure:
   # The property referenced below, AZURE_ENABLED, is not set in the
@@ -171,6 +187,18 @@ azure:
         version: 7.1.20150731
         osType: Linux
         packageType: rpm
+    - baseImage:
+        id: windows-2012-r2
+        shortDescription: 2012 R2
+        detailedDescription: Windows Server 2012 R2 Datacenter
+        publisher: MicrosoftWindowsServer
+        offer: WindowsServer
+        sku: 2012-R2-Datacenter
+        version: 4.0.20170111
+        osType: windows
+        packageType: nupkg
+        templateFile: azure-windows-2012-r2.json
+
 
 docker:
   # The property referenced below, DOCKER_ENABLED, is not set in the


### PR DESCRIPTION
There are 2 PR's that need to be merged before this PR can be merged. 

- Spinnaker: [PR #1390](https://github.com/spinnaker/spinnaker/pull/1390)
- Orca: [PR #1146](https://github.com/spinnaker/orca/pull/1146)

I've also raised an issue with Packer as when using the powershell provisioner via Spinnaker, the powershell command line isn't properly formed. Issuing the exact same packer command line via the command line works as expected. Please note that this only impacts Azure. AWS is working as expected.

- Packer issue: [Issue #4478](https://github.com/mitchellh/packer/issues/4478)
