### PR TITLE
Adding docker tag, organization and name handling

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandler.groovy
@@ -25,6 +25,8 @@ import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Clock
+
 @Component
 public class DockerBakeHandler extends CloudProviderBakeHandler {
 
@@ -67,10 +69,17 @@ public class DockerBakeHandler extends CloudProviderBakeHandler {
 
   @Override
   Map buildParameterMap(String region, def dockerVirtualizationSettings, String imageName, BakeRequest bakeRequest, String appVersionStr) {
+    String dockerTag = bakeRequest.extended_attributes?.get('docker_target_image_tag') ?: bakeRequest.commit_hash
+
+    if (!dockerTag) {
+      // If we can't set useful docker tag, we default to a unix timestamp
+      dockerTag = Clock.systemUTC().millis().toString()
+    }
+
     def parameterMap = [
       docker_source_image     : dockerVirtualizationSettings.sourceImage,
       docker_target_image     : imageName,
-      docker_target_image_tag : bakeRequest.request_id,
+      docker_target_image_tag : dockerTag,
       docker_target_repository: dockerBakeryDefaults.targetRepository
     ]
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactory.groovy
@@ -15,6 +15,7 @@ class DockerImageNameFactory extends ImageNameFactory {
   def buildImageName(BakeRequest bakeRequest, List<PackageNameConverter.OsPackageName> osPackageNames) {
 
     String imageName = bakeRequest.ami_name ?: osPackageNames.first()?.name
+
     String imageNamePrefixed = [bakeRequest.organization, imageName].findAll({it}).join("/")
 
     return imageNamePrefixed

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
@@ -52,8 +52,10 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
     setup:
       def clockMock = Mock(Clock)
       def imageNameFactory = new DockerImageNameFactory(clock: clockMock)
-      def bakeRequest = new BakeRequest(package_name: "superimage kato redis-server",
-        base_os: "centos")
+      def bakeRequest = new BakeRequest(package_name: "kato redis-server",
+        base_os: "centos",
+        ami_name:  'superimage',
+      )
       def osPackages = parseRpmOsPackageNames(bakeRequest.package_name)
     when:
       def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
@@ -63,6 +65,6 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       clockMock.millis() >> SOME_MILLISECONDS.toLong()
       imageName == "superimage"
       appVersionStr == SOME_MILLISECONDS
-      packagesParameter == "superimage kato redis-server"
+      packagesParameter == "kato redis-server"
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -12,6 +12,8 @@ trait TestDefaults {
   static final String SOME_MILLISECONDS = "1470391070464"
   static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
   static final String SOME_BUILD_INFO_URL = "http://some-build-server:8080/repogroup/repo/builds/320282"
+  static final String SOME_COMMIT_HASH = "170cdbd"
+  static final String SOME_DOCKER_TAG = "latest"
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))


### PR DESCRIPTION
This PR tries to let us use and control organization, tag and the image name for docker in a more coherent way while still respecting the current contract. My main motivation is to be able to enrich the bake step in deck for a separate PR. 