### PR TITLE
Refactor package and version handling

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -18,6 +18,10 @@ package com.netflix.spinnaker.rosco.api
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.rosco.providers.util.PackageUtil
+import com.netflix.spinnaker.rosco.providers.util.packagespecific.DebPackageUtil
+import com.netflix.spinnaker.rosco.providers.util.packagespecific.NupkgPackageUtil
+import com.netflix.spinnaker.rosco.providers.util.packagespecific.RpmPackageUtil
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
 import io.swagger.annotations.ApiModelProperty
@@ -84,24 +88,18 @@ class BakeRequest {
   }
 
   static enum PackageType {
-    RPM('rpm', '-'),
-    DEB('deb', '='),
-    NUPKG('nupkg', '.')
+    RPM(new RpmPackageUtil()),
+    DEB(new DebPackageUtil()),
+    NUPKG(new NupkgPackageUtil())
 
-    private final String packageType
-    private final String versionDelimiter
+    private final PackageUtil util
 
-    private PackageType(String packageType, String versionDelimiter) {
-      this.packageType = packageType
-      this.versionDelimiter = versionDelimiter
+    private PackageType(PackageUtil util) {
+      this.util = util
     }
 
-    String getPackageType() {
-      return this.packageType
-    }
-
-    String getVersionDelimiter() {
-      return this.versionDelimiter
+    PackageUtil getUtil() {
+      return util
     }
   }
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -161,7 +161,7 @@ abstract class CloudProviderBakeHandler {
       parameterMap.repository = chocolateyRepository
     }
 
-    parameterMap.package_type = selectedOptions.baseImage.packageType.packageType
+    parameterMap.package_type = selectedOptions.baseImage.packageType.util.packageType
     parameterMap.packages = packagesParameter
 
     if (bakeRequest.build_host) {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy
@@ -33,177 +33,16 @@ class PackageNameConverter {
     String arch
 
     public String qualifiedPackageName(PackageType packageType) {
-      if (version && release) {
-        "${name}${packageType.getVersionDelimiter()}${version}-${release}"
-      } else if (version) {
-        "${name}${packageType.getVersionDelimiter()}${version}"
+      if (version) {
+        "${name}${packageType.util.packageManagerVersionSeparator}${version}${release ? "-$release" : ""}"
       } else {
         return null
       }
     }
   }
 
-  // Naming-convention for debs is name_version-release_arch.
-  // For example: nflx-djangobase-enhanced_0.1-h12.170cdbd_all
-  public static OsPackageName parseDebPackageName(String fullyQualifiedPackageName) {
-    OsPackageName osPackageName = new OsPackageName()
-    if (!fullyQualifiedPackageName) return osPackageName
-
-    osPackageName.with {
-      name = fullyQualifiedPackageName
-
-      List<String> parts = fullyQualifiedPackageName?.tokenize("_")
-
-      if (parts) {
-        if (parts.size() > 1) {
-          List<String> versionReleaseParts = parts[1].tokenize("-")
-
-          if (versionReleaseParts) {
-            version = versionReleaseParts[0]
-            name = parts[0]
-
-            if (versionReleaseParts.size() > 1) {
-              release = versionReleaseParts[1]
-            }
-          }
-
-          if (parts.size() > 2) {
-            arch = parts[2]
-          }
-        }
-      }
-    }
-
-    osPackageName
-  }
-
-  // Naming-convention for rpms is name-version-release.arch.
-  // For example: nflx-djangobase-enhanced-0.1-h12.170cdbd.all
-  public static OsPackageName parseRpmPackageName(String fullyQualifiedPackageName) {
-    OsPackageName osPackageName = new OsPackageName()
-    if (!fullyQualifiedPackageName) return osPackageName
-
-    osPackageName.with {
-      name = fullyQualifiedPackageName
-
-      List<String> nameParts = fullyQualifiedPackageName.tokenize(".")
-      int numberOfNameParts = nameParts.size()
-
-      if (numberOfNameParts >= 2) {
-        arch = nameParts.drop(numberOfNameParts - 1).join("")
-        fullyQualifiedPackageName = nameParts.take(numberOfNameParts - 1).join(".")
-      }
-
-      List<String> parts = fullyQualifiedPackageName.tokenize("-")
-
-      if (parts.size() >= 3) {
-        release = parts.pop()
-        version = parts.pop()
-        name = parts.join("-")
-      }
-    }
-
-    osPackageName
-  }
-
-  // Nuget supports SemVer 1.0 for package versioning standards.
-  // Therefore, the naming convention for nuget packages is
-  // {package-name}[.{language}].{major}.{minor}.{patch/build}[-{version}][.{revision}][+{metadata}]
-  // For example: ContosoUtilities.ja-JP.1.0.0-rc1.nupkg
-  //              notepadplusplus.7.3.nupkg
-  //              autohotkey.1.1.24.04.nupkg
-  //              microsoft-aspnet-mvc.6.0.0-rc1-final.nupkg
-  //              microsoft-aspnet-mvc.de.3.0.50813.1.nupkg
-  //              microsoft.aspnet.mvc.6.0.0-rc1-final.nupkg
-  //              microsoft.aspnet.mvc.de.3.0.50813.1.nupkg
-  public static OsPackageName parseNupkgPackageName(String fullyQualifiedPackageName) {
-    OsPackageName osPackageName = new OsPackageName()
-    if (!fullyQualifiedPackageName) return osPackageName
-
-    fullyQualifiedPackageName = fullyQualifiedPackageName.replaceFirst('.nupkg', '')
-
-    osPackageName.with {
-      name = fullyQualifiedPackageName
-
-      List<String> parts = fullyQualifiedPackageName.tokenize(".")
-
-      if (parts.size() > 2) {
-        def versionStart = 0
-
-        for (def i = 0; i < parts.size(); i++) {
-          if (i > 0 && parts[i].isInteger()) {
-            versionStart = i
-            break
-          }
-        }
-
-        if (versionStart < 1) {
-          for (def i = 0; i < parts.size(); i++) {
-            if (i > 0 && parts[i].contains('-') && parts[i][0].isInteger()) {
-              versionStart = i
-              break
-            }
-          }
-        }
-
-        if (versionStart > 0) {
-
-          name = parts.subList(0, versionStart).join('.')
-          version = parts.subList(versionStart, parts.size()).join('.')
-
-          if (version.contains('-')) {
-            (version, release) = version.split('-', 2)
-          } else if (version.contains("+")) {
-            (version, release) = version.split("\\+", 2)
-            release = '+' + release
-          }
-
-        } else {
-
-          def metaDataIndex = parts.findIndexOf { val -> val =~ /\+/ }
-
-          if (metaDataIndex > -1) {
-            (name, release) = parts[metaDataIndex].split('\\+')
-            release = "+" + release
-            name = parts.subList(0, metaDataIndex).join('.') + "." + name
-          } else {
-            name = parts.join('.')
-          }
-        }
-
-      } else if (parts.size() == 2) {
-
-        if (parts[1].isInteger()) {
-          name = parts[0]
-          version = parts[1]
-        } else if (parts[1][0].isInteger() && parts[1].contains('-')) {
-
-            name = parts[0]
-
-            def versionParts = parts[1].split('-', 2)
-            version = versionParts[0]
-            release = versionParts[1]
-
-        } else {
-          name = parts.join(".")
-        }
-      }
-    }
-
-    osPackageName
-  }
-
   public static OsPackageName buildOsPackageName(BakeRequest.PackageType packageType, String packageName) {
-    switch (packageType) {
-      case BakeRequest.PackageType.DEB:
-        return PackageNameConverter.parseDebPackageName(packageName)
-      case BakeRequest.PackageType.RPM:
-        return PackageNameConverter.parseRpmPackageName(packageName)
-      case BakeRequest.PackageType.NUPKG:
-        return PackageNameConverter.parseNupkgPackageName(packageName)
-      default:
-        throw new IllegalArgumentException("Unrecognized packageType '$packageType'.")
-    }
+    packageType.util.parsePackageName(packageName)
   }
 
   public static List<OsPackageName> buildOsPackageNames(BakeRequest.PackageType packageType, List<String> packageNames) {
@@ -219,19 +58,15 @@ class PackageNameConverter {
     //   subscriberha-1.0.0-h150.586499/WE-WAPP-subscriberha/150
     String appVersion = osPackageName.name
 
-    def versionSeparator = packageType == BakeRequest.PackageType.NUPKG ? "." : "-"
-    def buildNumberSeparator = packageType == BakeRequest.PackageType.NUPKG ? "-" : "-h"
-    def commitHashSeparator = packageType == BakeRequest.PackageType.NUPKG ? "+" : "."
-
     osPackageName.with {
       if (version) {
-        appVersion += "$versionSeparator$version"
+        appVersion += "$packageType.util.versionSeparator$version"
 
         if (bakeRequest.build_number) {
-          appVersion += "$buildNumberSeparator$bakeRequest.build_number"
+          appVersion += "$packageType.util.buildNumberSeparator$bakeRequest.build_number"
 
           if (bakeRequest.commit_hash) {
-            appVersion += "$commitHashSeparator$bakeRequest.commit_hash"
+            appVersion += "$packageType.util.commitHashSeparator$bakeRequest.commit_hash"
           }
 
           if (bakeRequest.job) {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageUtil.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageUtil.groovy
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.rosco.providers.util
+
+import static com.netflix.spinnaker.rosco.providers.util.PackageNameConverter.OsPackageName
+
+interface PackageUtil {
+
+    String getPackageType()
+    String getPackageManagerVersionSeparator()
+    String getVersionSeparator()
+    String getBuildNumberSeparator()
+    String getCommitHashSeparator()
+    OsPackageName parsePackageName(String fullyQualifiedPackageName)
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/DebPackageUtil.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/DebPackageUtil.groovy
@@ -1,0 +1,70 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageUtil
+
+import static com.netflix.spinnaker.rosco.providers.util.PackageNameConverter.OsPackageName
+
+class DebPackageUtil implements PackageUtil {
+
+
+  @Override
+  String getPackageType() {
+    return 'deb'
+  }
+
+  @Override
+  String getPackageManagerVersionSeparator() {
+    return '='
+  }
+
+  @Override
+  String getVersionSeparator() {
+    return '-'
+  }
+
+  @Override
+  String getBuildNumberSeparator() {
+    return '-h'
+  }
+
+  @Override
+  String getCommitHashSeparator() {
+    return '.'
+  }
+
+  @Override
+  OsPackageName parsePackageName(String fullyQualifiedPackageName) {
+    // Naming-convention for debs is name_version-release_arch.
+    // For example: nflx-djangobase-enhanced_0.1-h12.170cdbd_all
+
+    OsPackageName osPackageName = new OsPackageName()
+    if (!fullyQualifiedPackageName) return osPackageName
+
+    osPackageName.with {
+      name = fullyQualifiedPackageName
+
+      List<String> parts = fullyQualifiedPackageName?.tokenize('_')
+
+      if (parts) {
+        if (parts.size() > 1) {
+          List<String> versionReleaseParts = parts[1].tokenize('-')
+
+          if (versionReleaseParts) {
+            version = versionReleaseParts[0]
+            name = parts[0]
+
+            if (versionReleaseParts.size() > 1) {
+              release = versionReleaseParts[1]
+            }
+          }
+
+          if (parts.size() > 2) {
+            arch = parts[2]
+          }
+        }
+      }
+    }
+
+    return osPackageName
+  }
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/NupkgPackageUtil.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/NupkgPackageUtil.groovy
@@ -1,0 +1,122 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageUtil
+
+import static com.netflix.spinnaker.rosco.providers.util.PackageNameConverter.OsPackageName
+
+class NupkgPackageUtil implements PackageUtil {
+
+  @Override
+  String getPackageType() {
+    return 'nupkg'
+  }
+
+  @Override
+  String getPackageManagerVersionSeparator() {
+    return '.'
+  }
+
+  @Override
+  String getVersionSeparator() {
+    return '.'
+  }
+
+  @Override
+  String getBuildNumberSeparator() {
+    return '-'
+  }
+
+  @Override
+  String getCommitHashSeparator() {
+    return '+'
+  }
+
+  @Override
+  OsPackageName parsePackageName(String fullyQualifiedPackageName) {
+    // Nuget supports SemVer 1.0 for package versioning standards.
+    // Therefore, the naming convention for nuget packages is
+    // {package-name}[.{language}].{major}.{minor}.{patch/build}[-{version}][.{revision}][+{metadata}]
+    // For example: ContosoUtilities.ja-JP.1.0.0-rc1.nupkg
+    //              notepadplusplus.7.3.nupkg
+    //              autohotkey.1.1.24.04.nupkg
+    //              microsoft-aspnet-mvc.6.0.0-rc1-final.nupkg
+    //              microsoft-aspnet-mvc.de.3.0.50813.1.nupkg
+    //              microsoft.aspnet.mvc.6.0.0-rc1-final.nupkg
+    //              microsoft.aspnet.mvc.de.3.0.50813.1.nupkg
+
+    OsPackageName osPackageName = new OsPackageName()
+    if (!fullyQualifiedPackageName) return osPackageName
+
+    fullyQualifiedPackageName = fullyQualifiedPackageName.replaceFirst('.nupkg', '')
+
+    osPackageName.with {
+      name = fullyQualifiedPackageName
+
+      List<String> parts = fullyQualifiedPackageName.tokenize('.')
+
+      if (parts.size() > 2) {
+        def versionStart = 0
+
+        for (def i = 0; i < parts.size(); i++) {
+          if (i > 0 && parts[i].isInteger()) {
+            versionStart = i
+            break
+          }
+        }
+
+        if (versionStart < 1) {
+          for (def i = 0; i < parts.size(); i++) {
+            if (i > 0 && parts[i].contains('-') && parts[i][0].isInteger()) {
+              versionStart = i
+              break
+            }
+          }
+        }
+
+        if (versionStart > 0) {
+
+          name = parts.subList(0, versionStart).join('.')
+          version = parts.subList(versionStart, parts.size()).join('.')
+
+          if (version.contains('-')) {
+            (version, release) = version.split('-', 2)
+          } else if (version.contains('+')) {
+            (version, release) = version.split(/\+/, 2)
+            release = '+' + release
+          }
+
+        } else {
+
+          def metaDataIndex = parts.findIndexOf { val -> val =~ /\+/ }
+
+          if (metaDataIndex > -1) {
+            (name, release) = parts[metaDataIndex].split(/\+/)
+            release = "+" + release
+            name = "${parts.subList(0, metaDataIndex).join('.')}.$name"
+          } else {
+            name = parts.join('.')
+          }
+        }
+
+      } else if (parts.size() == 2) {
+
+        if (parts[1].isInteger()) {
+          name = parts[0]
+          version = parts[1]
+        } else if (parts[1][0].isInteger() && parts[1].contains('-')) {
+
+          name = parts[0]
+
+          def versionParts = parts[1].split('-', 2)
+          version = versionParts[0]
+          release = versionParts[1]
+
+        } else {
+          name = parts.join('.')
+        }
+      }
+    }
+
+    return osPackageName
+  }
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/RpmPackageUtil.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/RpmPackageUtil.groovy
@@ -1,0 +1,63 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageUtil
+
+import static com.netflix.spinnaker.rosco.providers.util.PackageNameConverter.OsPackageName
+
+class RpmPackageUtil implements PackageUtil {
+
+  @Override
+  String getPackageType() {
+    return 'rpm'
+  }
+
+  @Override
+  String getPackageManagerVersionSeparator() {
+    return '-'
+  }
+
+  @Override
+  String getVersionSeparator() {
+    return '-'
+  }
+
+  @Override
+  String getBuildNumberSeparator() {
+    return '-h'
+  }
+
+  @Override
+  String getCommitHashSeparator() {
+    return '.'
+  }
+
+  @Override
+  OsPackageName parsePackageName(String fullyQualifiedPackageName) {
+    // Naming-convention for rpms is name-version-release.arch.
+    // For example: nflx-djangobase-enhanced-0.1-h12.170cdbd.all
+    OsPackageName osPackageName = new OsPackageName()
+    if (!fullyQualifiedPackageName) return osPackageName
+
+    osPackageName.with {
+      name = fullyQualifiedPackageName
+
+      List<String> nameParts = fullyQualifiedPackageName.tokenize('.')
+      int numberOfNameParts = nameParts.size()
+
+      if (numberOfNameParts >= 2) {
+        arch = nameParts.drop(numberOfNameParts - 1).join('')
+        fullyQualifiedPackageName = nameParts.take(numberOfNameParts - 1).join('.')
+      }
+
+      List<String> parts = fullyQualifiedPackageName.tokenize('-')
+
+      if (parts.size() >= 3) {
+        release = parts.pop()
+        version = parts.pop()
+        name = parts.join('-')
+      }
+    }
+
+    return osPackageName
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -308,7 +308,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_UBUNTU_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -348,7 +348,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_AMZN_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: YUM_REPOSITORY,
-        package_type: RPM_PACKAGE_TYPE.packageType,
+        package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -412,7 +412,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_AMZN_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: YUM_REPOSITORY,
-        package_type: RPM_PACKAGE_TYPE.packageType,
+        package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -454,7 +454,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: "ami-12345678",
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -494,7 +494,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -535,7 +535,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -576,7 +576,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
         someAttr1: "someValue1",
@@ -618,7 +618,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -656,7 +656,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                         build_info_url: buildInfoUrl,
                                         cloud_provider_type: BakeRequest.CloudProviderType.aws)
       def targetImageName = "kato-x8664-timestamp-trusty"
-      def osPackages = [PackageNameConverter.parseDebPackageName(fullyQualifiedPackageName)]
+      def osPackages = [PackageNameConverter.buildOsPackageName(DEB_PACKAGE_TYPE, fullyQualifiedPackageName)]
       def parameterMap = [
         aws_region: REGION,
         aws_ssh_username: "ubuntu",
@@ -664,7 +664,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir,
         appversion: appVersionStr,
@@ -708,7 +708,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_source_ami: SOURCE_UBUNTU_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         upgrade: true,
         configDir: configDir
@@ -749,7 +749,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       aws_source_ami: SOURCE_WINDOWS_2012_R2_HVM_IMAGE_NAME,
       aws_target_ami: targetImageName,
       repository: CHOCOLATEY_REPOSITORY,
-      package_type: NUPKG_PACKAGE_TYPE.packageType,
+      package_type: NUPKG_PACKAGE_TYPE.util.packageType,
       packages: NUPKG_PACKAGES_NAME,
       configDir: configDir
     ]
@@ -967,7 +967,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         repository: DEBIAN_REPOSITORY,
         packages: fullyQualifiedPackageName,
         share_with_1: "000001",
@@ -1021,7 +1021,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         repository: DEBIAN_REPOSITORY,
         packages: fullyQualifiedPackageName,
         copy_to_1: "us-west-1",

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.rosco.api.BakeOptions
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
 import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
-import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
 import com.netflix.spinnaker.rosco.providers.util.PackerCommandFactory
 import com.netflix.spinnaker.rosco.providers.util.TestDefaults
 import spock.lang.Shared
@@ -260,7 +259,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
         azure_image_sku: IMAGE_SKU,
         azure_image_name: IMAGE_NAME,
         repository: DEBIAN_REPOSITORY,
-        package_type: BakeRequest.PackageType.DEB.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -309,7 +308,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
       azure_image_sku: IMAGE_SKU_WINDOWS,
       azure_image_name: IMAGE_NAME,
       repository: CHOCOLATEY_REPOSITORY,
-      package_type: NUPKG_PACKAGE_TYPE.packageType,
+      package_type: NUPKG_PACKAGE_TYPE.util.packageType,
       packages: NUPKG_PACKAGES_NAME,
       configDir: configDir
     ]

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -163,7 +163,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         docker_target_image_tag: SOME_COMMIT_HASH,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -206,7 +206,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         docker_target_image_tag: SOME_COMMIT_HASH,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -249,7 +249,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         docker_target_image_tag: SOME_DOCKER_TAG,
         docker_target_repository: TARGET_REPOSITORY,
         repository: YUM_REPOSITORY,
-        package_type: RPM_PACKAGE_TYPE.packageType,
+        package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -285,7 +285,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                         request_id: SOME_UUID,
                                         extended_attributes: [docker_target_image_tag: SOME_DOCKER_TAG],
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
-      def osPackage = PackageNameConverter.parseDebPackageName(bakeRequest.package_name)
+      def osPackage = PackageNameConverter.buildOsPackageName(DEB_PACKAGE_TYPE, bakeRequest.package_name)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def parameterMap = [
         appversion: SOME_MILLISECONDS,
@@ -295,7 +295,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         docker_target_image_tag: SOME_DOCKER_TAG,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir,
         build_host: buildHost
@@ -348,7 +348,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         docker_target_image_tag: SOME_COMMIT_HASH,
         docker_target_repository: TARGET_REPOSITORY,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir
       ]

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -208,7 +208,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_PRECISE_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -248,7 +248,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_CENTOS_HVM_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: YUM_REPOSITORY,
-        package_type: RPM_PACKAGE_TYPE.packageType,
+        package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -289,7 +289,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: "some-gce-image-name",
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -330,7 +330,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_PRECISE_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -371,7 +371,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_PRECISE_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
         someAttr1: "someValue1",
@@ -419,7 +419,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_PRECISE_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -460,7 +460,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_PRECISE_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -502,7 +502,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -539,7 +539,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                         build_host: buildHost,
                                         build_info_url: buildInfoUrl,
                                         cloud_provider_type: BakeRequest.CloudProviderType.gce)
-      def osPackage = PackageNameConverter.parseDebPackageName(bakeRequest.package_name)
+      def osPackage = PackageNameConverter.buildOsPackageName(DEB_PACKAGE_TYPE, bakeRequest.package_name)
       def targetImageName = "kato-x8664-timestamp-trusty"
       def parameterMap = [
         gce_project_id: googleConfigurationProperties.accounts.get(0).project,
@@ -548,7 +548,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir,
         appversion: appVersionStr,
@@ -593,7 +593,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_TRUSTY_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -633,7 +633,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image_family: SOURCE_XENIAL_IMAGE_NAME + "-family",
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -674,7 +674,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: "some-gce-image-name",
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -714,7 +714,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         gce_source_image: SOURCE_YAKKETY_IMAGE_NAME,
         gce_target_image: targetImageName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
@@ -243,7 +243,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -297,7 +297,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
             openstack_security_groups: openstackBakeryDefaults.securityGroups,
             openstack_project_name: openstackBakeryDefaults.projectName,
             repository: DEBIAN_REPOSITORY,
-            package_type: BakeRequest.PackageType.DEB.packageType,
+            package_type: BakeRequest.PackageType.DEB.util.packageType,
             packages: PACKAGES_NAME,
             configDir: configDir,
             appversion: appVersionStr,
@@ -350,7 +350,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -401,7 +401,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -451,7 +451,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
         someAttr1: "someValue1",
@@ -503,7 +503,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir
       ]
@@ -553,7 +553,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         openstack_security_groups: openstackBakeryDefaults.securityGroups,
         openstack_project_name: openstackBakeryDefaults.projectName,
         repository: DEBIAN_REPOSITORY,
-        package_type: DEB_PACKAGE_TYPE.packageType,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
         upgrade: true

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverterSpec.groovy
@@ -18,132 +18,8 @@ package com.netflix.spinnaker.rosco.providers.util
 
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class PackageNameConverterSpec extends Specification implements TestDefaults {
-  @Unroll
-  void "deb package names are properly parsed"() {
-    when:
-      def osPackageName = PackageNameConverter.parseDebPackageName(packageName)
-
-    then:
-      osPackageName == expectedOsPackageName
-
-    where:
-      packageName                                    | expectedOsPackageName
-      null                                           | new PackageNameConverter.OsPackageName()
-      ""                                             | new PackageNameConverter.OsPackageName()
-      "nflx-djangobase-enhanced"                     | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced")
-      "nflx-djangobase-enhanced_0.1"                 | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1")
-      "nflx-djangobase-enhanced_0.1-h12.170cdbd"     | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1",
-                                                                                              release: "h12.170cdbd")
-      "nflx-djangobase-enhanced_0.1-3"               | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1",
-                                                                                              release: "3")
-      "nflx-djangobase-enhanced_0.1-h12.170cdbd_all" | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1",
-                                                                                              release: "h12.170cdbd",
-                                                                                              arch: "all")
-      "nflx-djangobase-enhanced_0.1-3_all"           | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1",
-                                                                                              release: "3",
-                                                                                              arch: "all")
-  }
-
-  @Unroll
-  void "rpm package names are properly parsed"() {
-    when:
-      def osPackageName = PackageNameConverter.parseRpmPackageName(packageName)
-
-    then:
-      osPackageName == expectedOsPackageName
-
-    where:
-      packageName                                    | expectedOsPackageName
-      null                                           | new PackageNameConverter.OsPackageName()
-      ""                                             | new PackageNameConverter.OsPackageName()
-      "billinggateway-1.0-h2385.e0a09ce.all"         | new PackageNameConverter.OsPackageName(name: "billinggateway",
-                                                                                              version: "1.0",
-                                                                                              release: "h2385.e0a09ce",
-                                                                                              arch: "all")
-      "nflx-djangobase-enhanced-0.1-h12.170cdbd.all" | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "0.1",
-                                                                                              release: "h12.170cdbd",
-                                                                                              arch: "all")
-      "sf-lucifer-0.0.10-1.noarch"                   | new PackageNameConverter.OsPackageName(name: "sf-lucifer",
-                                                                                              version: "0.0.10",
-                                                                                              release: "1",
-                                                                                              arch: "noarch")
-  }
-
-  @Unroll
-  void "nupkg package names are properly parsed"() {
-    when:
-      def osPackageName = PackageNameConverter.parseNupkgPackageName(packageName)
-
-    then:
-      osPackageName == expectedOsPackageName
-
-    where:
-      packageName                                    | expectedOsPackageName
-      null                                           | new PackageNameConverter.OsPackageName()
-      ""                                             | new PackageNameConverter.OsPackageName()
-      "billinggateway.1.0.1"                         | new PackageNameConverter.OsPackageName(name: "billinggateway",
-                                                                                              version: "1.0.1",
-                                                                                              release: null,
-                                                                                              arch: null)
-      "nflx-djangobase-enhanced.1.0.1-rc1"           | new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
-                                                                                              version: "1.0.1",
-                                                                                              release: "rc1",
-                                                                                              arch: null)
-      "sf-lucifer.en-US.0.0.10-1"                    | new PackageNameConverter.OsPackageName(name: "sf-lucifer.en-US",
-                                                                                              version: "0.0.10",
-                                                                                              release: "1",
-                                                                                              arch: null)
-      "microsoft.aspnet.mvc"                         | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
-                                                                                              version: null,
-                                                                                              release: null,
-                                                                                              arch: null)
-      "microsoft.aspnet.mvc.6"                       | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
-                                                                                              version: "6",
-                                                                                              release: null,
-                                                                                              arch: null)
-      "microsoft.aspnet.mvc.6-rc1-final"             | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
-                                                                                              version: "6",
-                                                                                              release: "rc1-final",
-                                                                                              arch: null)
-      "microsoft.aspnet.mvc.6.0.0+sf23sdf"           | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
-                                                                                              version: "6.0.0",
-                                                                                              release: "+sf23sdf",
-                                                                                              arch: null)
-      "microsoft.aspnet.mvc.6.0.0-rc1-final+sf23sdf" | new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
-                                                                                              version: "6.0.0",
-                                                                                              release: "rc1-final+sf23sdf",
-                                                                                              arch: null)
-      "microsoft-aspnet-mvc"                         | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
-                                                                                              version: null,
-                                                                                              release: null,
-                                                                                              arch: null)
-      "microsoft-aspnet-mvc.6"                       | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
-                                                                                              version: "6",
-                                                                                              release: null,
-                                                                                              arch: null)
-      "microsoft-aspnet-mvc.6-rc1-final"             | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
-                                                                                              version: "6",
-                                                                                              release: "rc1-final",
-                                                                                              arch: null)
-      "microsoft-aspnet-mvc.6.0.0+sf23sdf"           | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
-                                                                                              version: "6.0.0",
-                                                                                              release: "+sf23sdf",
-                                                                                              arch: null)
-      "microsoft-aspnet-mvc.6.0.0-rc1-final+sf23sdf" | new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
-                                                                                              version: "6.0.0",
-                                                                                              release: "rc1-final+sf23sdf",
-                                                                                              arch: null)
-
-  }
 
   void "package type is respected when building app version string"() {
     setup:
@@ -152,8 +28,8 @@ class PackageNameConverterSpec extends Specification implements TestDefaults {
       def appVersionStr = "nflx-djangobase-enhanced-0.1-h12.170cdbd"
 
     when:
-      def parsedDebPackageName = PackageNameConverter.parseDebPackageName(debPackageName)
-      def parsedRpmPackageName = PackageNameConverter.parseRpmPackageName(rpmPackageName)
+      def parsedDebPackageName = PackageNameConverter.buildOsPackageName(DEB_PACKAGE_TYPE, debPackageName)
+      def parsedRpmPackageName = PackageNameConverter.buildOsPackageName(RPM_PACKAGE_TYPE, rpmPackageName)
       def appVersionStrFromDebPackageName = PackageNameConverter.buildAppVersionStr(
         new BakeRequest(base_os: "ubuntu",
                         build_number: "12",

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/DebPackageUtilSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/DebPackageUtilSpec.groovy
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DebPackageUtilSpec extends Specification implements TestDefaults {
+  @Unroll
+  void "deb package names are properly parsed"() {
+    when:
+      def osPackageName = new DebPackageUtil().parsePackageName(packageName)
+
+    then:
+      osPackageName == expectedOsPackageName
+
+    where:
+      packageName                                    || expectedOsPackageName
+      null                                           || new PackageNameConverter.OsPackageName()
+      ""                                             || new PackageNameConverter.OsPackageName()
+      "nflx-djangobase-enhanced"                     || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced")
+      "nflx-djangobase-enhanced_0.1"                 || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "0.1")
+      "nflx-djangobase-enhanced_0.1-h12.170cdbd"     || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "0.1",
+                                                                                               release: "h12.170cdbd")
+      "nflx-djangobase-enhanced_0.1-3"               || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "0.1",
+                                                                                               release: "3")
+      "nflx-djangobase-enhanced_0.1-h12.170cdbd_all" || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "0.1",
+                                                                                               release: "h12.170cdbd",
+                                                                                               arch: "all")
+      "nflx-djangobase-enhanced_0.1-3_all"           || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "0.1",
+                                                                                               release: "3",
+                                                                                               arch: "all")
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/NupkgPackageUtilSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/NupkgPackageUtilSpec.groovy
@@ -1,0 +1,75 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NupkgPackageUtilSpec extends Specification implements TestDefaults {
+  @Unroll
+  void "nupkg package names are properly parsed"() {
+    when:
+      def osPackageName = new NupkgPackageUtil().parsePackageName(packageName)
+
+    then:
+      osPackageName == expectedOsPackageName
+
+    where:
+      packageName                                    || expectedOsPackageName
+      null                                           || new PackageNameConverter.OsPackageName()
+      ""                                             || new PackageNameConverter.OsPackageName()
+      "billinggateway.1.0.1"                         || new PackageNameConverter.OsPackageName(name: "billinggateway",
+                                                                                               version: "1.0.1",
+                                                                                               release: null,
+                                                                                               arch: null)
+      "nflx-djangobase-enhanced.1.0.1-rc1"           || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                               version: "1.0.1",
+                                                                                               release: "rc1",
+                                                                                               arch: null)
+      "sf-lucifer.en-US.0.0.10-1"                    || new PackageNameConverter.OsPackageName(name: "sf-lucifer.en-US",
+                                                                                               version: "0.0.10",
+                                                                                               release: "1",
+                                                                                               arch: null)
+      "microsoft.aspnet.mvc"                         || new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                               version: null,
+                                                                                               release: null,
+                                                                                               arch: null)
+      "microsoft.aspnet.mvc.6"                       || new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                               version: "6",
+                                                                                               release: null,
+                                                                                               arch: null)
+      "microsoft.aspnet.mvc.6-rc1-final"             || new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                               version: "6",
+                                                                                               release: "rc1-final",
+                                                                                               arch: null)
+      "microsoft.aspnet.mvc.6.0.0+sf23sdf"           || new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                               version: "6.0.0",
+                                                                                               release: "+sf23sdf",
+                                                                                               arch: null)
+      "microsoft.aspnet.mvc.6.0.0-rc1-final+sf23sdf" || new PackageNameConverter.OsPackageName(name: "microsoft.aspnet.mvc",
+                                                                                               version: "6.0.0",
+                                                                                               release: "rc1-final+sf23sdf",
+                                                                                               arch: null)
+      "microsoft-aspnet-mvc"                         || new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                               version: null,
+                                                                                               release: null,
+                                                                                               arch: null)
+      "microsoft-aspnet-mvc.6"                       || new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                               version: "6",
+                                                                                               release: null,
+                                                                                               arch: null)
+      "microsoft-aspnet-mvc.6-rc1-final"             || new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                               version: "6",
+                                                                                               release: "rc1-final",
+                                                                                               arch: null)
+      "microsoft-aspnet-mvc.6.0.0+sf23sdf"           || new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                               version: "6.0.0",
+                                                                                               release: "+sf23sdf",
+                                                                                               arch: null)
+      "microsoft-aspnet-mvc.6.0.0-rc1-final+sf23sdf" || new PackageNameConverter.OsPackageName(name: "microsoft-aspnet-mvc",
+                                                                                               version: "6.0.0",
+                                                                                               release: "rc1-final+sf23sdf",
+                                                                                               arch: null)
+
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/RpmPackageUtilSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/packagespecific/RpmPackageUtilSpec.groovy
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.rosco.providers.util.packagespecific
+
+import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class RpmPackageUtilSpec extends Specification implements TestDefaults {
+  @Unroll
+  void "rpm package names are properly parsed"() {
+    when:
+      def osPackageName = new RpmPackageUtil().parsePackageName(packageName)
+
+    then:
+      osPackageName == expectedOsPackageName
+
+    where:
+      packageName                                    || expectedOsPackageName
+      null                                           || new PackageNameConverter.OsPackageName()
+      ""                                             || new PackageNameConverter.OsPackageName()
+      "billinggateway-1.0-h2385.e0a09ce.all"         || new PackageNameConverter.OsPackageName(name: "billinggateway",
+                                                                                              version: "1.0",
+                                                                                              release: "h2385.e0a09ce",
+                                                                                              arch: "all")
+      "nflx-djangobase-enhanced-0.1-h12.170cdbd.all" || new PackageNameConverter.OsPackageName(name: "nflx-djangobase-enhanced",
+                                                                                              version: "0.1",
+                                                                                              release: "h12.170cdbd",
+                                                                                              arch: "all")
+      "sf-lucifer-0.0.10-1.noarch"                   || new PackageNameConverter.OsPackageName(name: "sf-lucifer",
+                                                                                              version: "0.0.10",
+                                                                                              release: "1",
+                                                                                              arch: "noarch")
+  }
+}


### PR DESCRIPTION
This should make it easier to add more implementations in the future.
No new features, only refactoring.

* Made a new PackageUtil interface and moved code into three different implementations (for rpm, nupkg and deb)
* Updated tests to reflect the new implementation