### PR TITLE
Allow for multiple RPM repositories

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -55,14 +55,17 @@ function provision_deb() {
 
 function provision_rpm() {
   if [[ "$repository" != "" ]]; then
-    cat > /tmp/spinnaker.repo <<EOF
-[spinnaker]
-name=spinnaker
-baseurl=$repository
+    IFS=';' read -ra repo <<< "$repository"
+    for i in "${!repo[@]}"; do
+      cat > /tmp/spinnaker-$i.repo <<EOF
+[spinnaker-$i]
+name=spinnaker-$i
+baseurl=${repo[$i]}
 gpgcheck=0
 enabled=1
 EOF
-    sudo mv /tmp/spinnaker.repo /etc/yum.repos.d/
+    done
+    sudo mv /tmp/spinnaker*.repo /etc/yum.repos.d/
   fi
 
   if [[ "$upgrade" == "true" ]]; then
@@ -74,7 +77,7 @@ EOF
 
   if [[ "$repository" != "" ]]; then
     # Cleanup repository configuration
-    sudo rm /etc/yum.repos.d/spinnaker.repo
+    sudo rm /etc/yum.repos.d/spinnaker*.repo
   fi
 }
 


### PR DESCRIPTION
Testing of this change was done in AWS and Azure environments targeting a CentOS 7.1 image. There are 2 ways to specify your target RPM repositories: setting the value of 'yumRepository' in your rosco-local.yml file or via an extended attribute in your bake state. For testing purposes, we used the extended attribute in our bake stage to override the configured value for the 'yumRepository' setting.

To replicate, add an extended attribute named 'repository' in the Bake Configuration of a bake stage. Set the value of this extended attribute to a semi-colon separated string (ie 'http://jfrog-artifactory.repo/artifactory/dotnet-core/;http://nginx.org/packages/centos/7/$basearch/'). In the 'Packages' field in the Bake Configuration, add a package from each repository (ie 'dotnet-core-runtime nginx'). After you start a manual bake, review the bakery log and you should see both packages being installed from their respective source.