### PR TITLE
Deprecate google.gce.bakeryDefaults in favor of google.bakeryDefaults

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/config/RoscoGoogleConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/config/RoscoGoogleConfiguration.groovy
@@ -45,6 +45,12 @@ class RoscoGoogleConfiguration {
 
   @Bean
   @ConfigurationProperties('google.gce.bakeryDefaults')
+  GCEBakeryDefaults deprecatedGCEBakeryDefaults() {
+    new GCEBakeryDefaults()
+  }
+
+  @Bean
+  @ConfigurationProperties('google.bakeryDefaults')
   GCEBakeryDefaults gceBakeryDefaults() {
     new GCEBakeryDefaults()
   }


### PR DESCRIPTION
This makes the google config more similar to that of the other providers.

The config in rosco-web was left untouched, since it would override existing configurations of rosco with this change in place.