### PR TITLE
fix(install): Wrap packer failure in function.

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,17 +12,20 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 # install packer
-PACKER_VERSION="0.12.1"
-packer_version=$(packer --version)
-packer_status=$?
-if [ $packer_status -ne 0 ] || [ "$packer_version" -ne "$PACKER_VERSION" ]; then
-  pushd .
-  cd /usr/bin
-  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
-  apt-get install unzip -y
-  unzip -o "packer_${PACKER_VERSION}_linux_amd64.zip"
-  rm "packer_${PACKER_VERSION}_linux_amd64.zip"
-  popd
-fi
+function install_packer() {
+  PACKER_VERSION="0.12.1"
+  local packer_version=$(packer --version)
+  local packer_status=$?
+  if [[ $packer_status -ne 0 ]] || [[ "$packer_version" != "$PACKER_VERSION" ]]; then
+    pushd .
+    cd /usr/bin
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
+    apt-get install unzip -y
+    unzip -o "packer_${PACKER_VERSION}_linux_amd64.zip"
+    rm "packer_${PACKER_VERSION}_linux_amd64.zip"
+    popd
+  fi
+}
 
+install_packer
 install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/rosco


### PR DESCRIPTION
Apparently `set -e` was called somewhere in the install scripts, so if `packer` isn't installed, `packer --version` fails, causing the install script to exit. Wrapping this in a function will let me inspect the return code and decide what to do safely.