### PR TITLE
To find packer version, use full path for packer. 

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -13,7 +13,7 @@ fi
 
 install_packer() {
   PACKER_VERSION="0.12.1"
-  local packer_version=$(packer --version)
+  local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then
     TEMPDIR=$(mktemp -d installrosco.XXXX)


### PR DESCRIPTION
This will be useful if the build system already pulls in packer but do not have path configured.

Also there is a bug in the post install script. It does apt-get install within apt-get install, so it will not succeed for those who are using deb package. Ideally unzip should be a dependency. Nonetheless this fix is necessary.