### PR TITLE
fix(Dockerfile): Navigate Docker's wonky COPY command.

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -4,8 +4,7 @@ MAINTAINER delivery-engineering@netflix.com
 
 COPY ./rosco-web/build/install/rosco /opt/rosco
 COPY ./rosco-web/config /opt/rosco
-COPY ./rosco-web/config/packer /opt/rosco/config
-COPY ./rosco-web/config/packer/scripts /opt/rosco/config/packer
+COPY ./rosco-web/config/packer /opt/rosco/config/packer
 
 WORKDIR /packer
 


### PR DESCRIPTION
I tested this locally on a Docker container and verified that
the config directory structure looks how we actually want it to this
time. @duftler FYI.  Sorry for the repeated attempts to solve this.