### PR TITLE
fix(Rosco/Chocolatey) Properly install Chocolatey (NUPKG) packages that include the package version (#1616)

### DIFF
--- a/rosco-web/config/packer/scripts/windows-configure-chocolatey.ps1
+++ b/rosco-web/config/packer/scripts/windows-configure-chocolatey.ps1
@@ -55,7 +55,6 @@ for ($i=0; $i -lt $repositories.Length; $i++) {
                                                  -TimeoutSec 60 `
                                                  -Headers $headers).StatusCode
                 $isValid = ($statusCode -ge 200 -and $statusCode -lt 300)
-                #Write-Host "Got to here 3:" + $repositories[$i] +"; IsValid: $isValid"
 
             } catch {
                 $ErrorMessage = $_.Exception.Message

--- a/rosco-web/config/packer/scripts/windows-install-packages.ps1
+++ b/rosco-web/config/packer/scripts/windows-install-packages.ps1
@@ -1,13 +1,87 @@
 $packages = @()
+
 if (![string]::IsNullOrWhiteSpace($env:packages)) {
 
     # Split supplied packages into an array.
     $packages = $env:packages.replace(',', ' ').split(' ')
 
     # Install packages and enforce installation order.
-    foreach ($package in $packages) {
-        if (![string]::IsNullOrWhiteSpace($package)) {
-            &"choco" install $package --yes
+    foreach ($packageName in $packages) {
+
+        if (![string]::IsNullOrWhiteSpace($packageName)) {
+
+            # Parse package name into it's constituent parts
+            [string]$packageVersion = ""
+            [string]$packageRelease = ""
+
+            # Split packageName into an array.
+            [Collections.Generic.List[String]]$parts = $packageName.split('.')
+
+            if ($parts.Count -gt 2) {
+                [int]$versionStart = 0
+
+                for ([int]$i = 0; $i -lt $parts.Count; $i++) {
+                  if ($i -gt 0 -and $parts[$i] -match '^\d+$') {
+                    $versionStart = $i
+                    break
+                  }
+                }
+
+                if ($versionStart -lt 1) {
+                  for ([int]$i = 0; $i -lt $partsCount; $i++) {
+                    if ($i -gt 0 -and $parts[$i].Contains('-') -and $parts[$i][0] -match '^\d+$') {
+                      $versionStart = $i
+                      break
+                    }
+                  }
+                }
+
+                if ($versionStart -gt 0) {
+                  $packageName = [String]::Join('.', $parts.GetRange(0, $versionStart).ToArray())
+                  $packageVersion = [String]::Join('.', $parts.GetRange($versionStart, $parts.Count - $versionStart).ToArray())
+
+                  if ($packageVersion.Contains('-')) {
+                    ($packageVersion, $packageRelease) = $packageVersion.Split('-', 2)
+                  } elseif ($packageVersion.Contains('+')) {
+                    ($packageVersion, $packageRelease) = $packageVersion.Split('+', 2)
+                    $packageRelease = '+' + $packageRelease
+                  }
+
+                } else {
+
+                  [int]$metaDataIndex = $parts.FindIndex( {$args[0] -match '\+'} )
+
+                  if ($metaDataIndex -gt -1) {
+                    ($packageName, $packageRelease) = $parts[$metaDataIndex].split('+')
+                    $packageRelease = "+" + $packageRelease
+                    $packageName = "${parts.subList(0, metaDataIndex).join('.')}.$name"
+                  } else {
+                    $packageName = [String]::Join('.', $parts)
+                  }
+                }
+            } elseif ($parts.Count -eq 2) {
+                if ($parts[1] -match '^\d+$') {
+                  $packageName = $parts[0]
+                  $packageVersion = $parts[1]
+                } elseif ($parts[1][0] -match '^\d+$' -and $parts[1].Contains('-')) {
+
+                  $packageName = $parts[0]
+
+                  $versionParts = $parts[1].Split('-', 2)
+                  $packageVersion = $versionParts[0]
+                  $packageRelease = $versionParts[1]
+
+                } else {
+                  $packageName = [String]::Join('.', $parts)
+                }
+            }
+        }
+
+        if (![string]::IsNullOrWhiteSpace($packageVersion)) {
+            &"choco" install $packageName --yes --version $packageVersion
+        } else {
+            &"choco" install $packageName --yes
         }
     }
 }
+


### PR DESCRIPTION
Updated Powershell script that is responsible for installing Chocolatey packages when baking Windows images to properly parse package names. The logic is now the same logic that is used in Rosco when parsing package names.

Package names like 'nodejs.install.7.9.0' are now split into name ('nodejs.install') and version ('7.9.0') and the version is now included when installing the package via Chocolatey command line.
