### PR TITLE
feat(artifact/decoration): Artifact decoration spinnaker/spinnaker#1348

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Artifact.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Artifact.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Schibsted ASA.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,20 +19,13 @@ package com.netflix.spinnaker.rosco.api
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-import io.swagger.annotations.ApiModelProperty
 
-/**
- * The details of a completed bake.
- *
- * @see BakeryController#lookupBake
- */
-@CompileStatic
-@EqualsAndHashCode(includes = "id")
+@EqualsAndHashCode
 @ToString(includeNames = true)
-class Bake {
-  @ApiModelProperty(value="The id of the bake job.")
-  String id
-  String ami
-  String image_name
-  Artifact artifact
+class Artifact {
+  String name
+  String type
+  String version
+  String reference
+  Map<String, String> metadata
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/BakeRecipe.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/BakeRecipe.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.jobs
+
+class BakeRecipe {
+  String name
+  String version
+  List<String> command
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/BakeStore.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.rosco.persistence
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.api.BakeStatus
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe
 
 /**
  * Persistence service for in-flight and completed bakes.
@@ -31,10 +32,10 @@ interface BakeStore {
   public boolean acquireBakeLock(String bakeKey)
 
   /**
-   * Store the region, bakeRequest and bakeStatus in association with both the bakeKey and bakeId. If bake key
+   * Store the region, bakeRecipe, bakeRequest and bakeStatus in association with both the bakeKey and bakeId. If bake key
    * has already been set, return a bakeStatus with that bake's id instead. None of the arguments may be null.
    */
-  public BakeStatus storeNewBakeStatus(String bakeKey, String region, BakeRequest bakeRequest, BakeStatus bakeStatus, String command)
+  public BakeStatus storeNewBakeStatus(String bakeKey, String region, BakeRecipe bakeRecipe, BakeRequest bakeRequest, BakeStatus bakeStatus, String command)
 
   /**
    * Update the completed bake details associated with both the bakeKey and bakeDetails.id. bakeDetails may not be null.
@@ -71,6 +72,16 @@ interface BakeStore {
    * Retrieve the bake status associated with the bakeId. bakeId may be null.
    */
   public BakeStatus retrieveBakeStatusById(String bakeId)
+
+  /**
+   * Retrieve the bake request associated with the bakeId.
+   */
+  public BakeRequest retrieveBakeRequestById(String bakeId)
+
+  /**
+   * Retrieve the bake recipe associated with the bakeId.
+   */
+  public BakeRecipe retrieveBakeRecipeById(String bakeId)
 
   /**
    * Retrieve the completed bake details associated with the bakeId. bakeId may be null.

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers
+
+import com.netflix.spinnaker.rosco.api.Artifact
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults {
+
+
+  void 'we should create a fully decorated artifact if all base data is present'() {
+    setup:
+      def expectedArtifact = new Artifact (
+        name: SOME_BAKE_RECIPE.name,
+        version: SOME_BAKE_RECIPE.version,
+        type: SOME_CLOUD_PROVIDER,
+        reference: SOME_BAKE_DETAILS.ami,
+        metadata: [
+          build_info_url: SOME_BAKE_REQUEST.build_info_url,
+          build_number: SOME_BAKE_REQUEST.build_number
+        ]
+      )
+
+      @Subject
+      CloudProviderBakeHandler bakeHandler = Spy(CloudProviderBakeHandler)
+
+    when:
+      Artifact producedArtifact = bakeHandler.produceArtifactDecorationFrom(SOME_BAKE_REQUEST, SOME_BAKE_RECIPE, SOME_BAKE_DETAILS, SOME_CLOUD_PROVIDER)
+
+    then:
+      producedArtifact == expectedArtifact
+  }
+
+  @Unroll
+  void 'we should not fail if data is missing for artifact decoration'() {
+    expect:
+      @Subject
+      CloudProviderBakeHandler bakeHandler = Spy(CloudProviderBakeHandler)
+      def decoratedArtifact = bakeHandler.produceArtifactDecorationFrom(bakeRequest, bakeRecipe, SOME_BAKE_DETAILS, SOME_CLOUD_PROVIDER)
+      decoratedArtifact.name == expectedName
+      decoratedArtifact.version == expectedVersion
+      decoratedArtifact.reference == expectedReference
+      decoratedArtifact.metadata == expectedMetadata
+
+    where:
+      bakeRequest       | bakeRecipe       | expectedName          | expectedVersion      | expectedReference | expectedMetadata
+      null              | null             | null                  | null                 | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
+      null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | SOME_APP_VERSION_STR | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
+      SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | SOME_APP_VERSION_STR | SOME_AMI_ID       | ["build_info_url": SOME_BUILD_INFO_URL, "build_number": SOME_BUILD_NR]
+
+  }
+
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -321,7 +321,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -361,7 +361,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          yumRepository: YUM_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -426,7 +426,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         yumRepository: YUM_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -467,7 +467,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -507,7 +507,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -548,7 +548,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -591,7 +591,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -631,7 +631,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -680,7 +680,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -722,7 +722,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -763,7 +763,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       chocolateyRepository: CHOCOLATEY_REPOSITORY)
 
     when:
-    awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+    awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -789,7 +789,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()
@@ -813,7 +813,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()
@@ -987,7 +987,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          yumRepository: YUM_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -1041,7 +1041,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
                                                          yumRepository: YUM_REPOSITORY)
 
     when:
-      awsBakeHandler.producePackerCommand(REGION, bakeRequest)
+      awsBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -273,7 +273,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
         azureConfigurationProperties: azureConfigurationProperties)
 
     when:
-      azureBakeHandler.producePackerCommand(REGION, bakeRequest)
+      azureBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -322,7 +322,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
       azureConfigurationProperties: azureConfigurationProperties)
 
     when:
-    azureBakeHandler.producePackerCommand(REGION, bakeRequest)
+    azureBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -176,7 +176,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                                                   debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -219,7 +219,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                                                   debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -262,7 +262,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                                                   yumRepository: YUM_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -309,7 +309,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                                                   debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
@@ -359,7 +359,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
         packerCommandFactory: packerCommandFactoryMock,
         debianRepository: DEBIAN_REPOSITORY)
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
     then:
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> targetImageTag
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetQualifiedImageName
@@ -403,7 +403,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
                                                                   debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      dockerBakeHandler.producePackerCommand(REGION, bakeRequest)
+      dockerBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -222,7 +222,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -262,7 +262,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          yumRepository: YUM_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -303,7 +303,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -344,7 +344,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -387,7 +387,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -433,7 +433,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -476,7 +476,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -516,7 +516,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -565,7 +565,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
@@ -607,7 +607,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -647,7 +647,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -688,7 +688,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -728,7 +728,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -753,7 +753,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()
@@ -777,7 +777,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()
@@ -803,7 +803,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      gceBakeHandler.producePackerCommand(REGION, bakeRequest)
+      gceBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/openstack/OpenstackBakeHandlerSpec.groovy
@@ -256,7 +256,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -313,7 +313,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
             debianRepository: DEBIAN_REPOSITORY)
 
     when:
-    openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+    openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -363,7 +363,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -414,7 +414,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -466,7 +466,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -516,7 +516,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -567,7 +567,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
@@ -592,7 +592,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION, bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION, bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()
@@ -615,7 +615,7 @@ class OpenstackBakeHandlerSpec extends Specification implements TestDefaults {
         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-      openstackBakeHandler.producePackerCommand(REGION + '999', bakeRequest)
+      openstackBakeHandler.produceBakeRecipe(REGION + '999', bakeRequest)
 
     then:
       IllegalArgumentException e = thrown()

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -1,6 +1,9 @@
 package com.netflix.spinnaker.rosco.providers.util
 
+import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.api.BakeRequest.CloudProviderType
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe
 
 trait TestDefaults {
 
@@ -9,14 +12,29 @@ trait TestDefaults {
   static final String DEBIAN_REPOSITORY = "http://some-debian-repository"
   static final String YUM_REPOSITORY = "http://some-yum-repository"
   static final String CHOCOLATEY_REPOSITORY = "http://some-chocolatey-repository"
-  static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
-  static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
-  static final BakeRequest.PackageType NUPKG_PACKAGE_TYPE = BakeRequest.PackageType.NUPKG
+  static final CloudProviderType DOCKER_CLOUD_PROVIDER = BakeRequest.CloudProviderType.docker
+
   static final String SOME_MILLISECONDS = "1470391070464"
   static final String SOME_UUID = "55c25239-4de5-4f7a-b664-6070a1389680"
   static final String SOME_BUILD_INFO_URL = "http://some-build-server:8080/repogroup/repo/builds/320282"
+  static final String SOME_BUILD_NR = "42"
   static final String SOME_COMMIT_HASH = "170cdbd"
   static final String SOME_DOCKER_TAG = "latest"
+  static final String SOME_APP_VERSION_STR = "nflx-djangobase-enhanced-0.1-h12.170cdbd"
+  static final String SOME_BAKE_RECIPE_NAME = "djangobase"
+  static final String SOME_JOB_ID = "123"
+  static final String SOME_AMI_ID = "ami-3cf4a854"
+  static final String SOME_IMAGE_NAME = "ubuntu/trusty"
+  static final String SOME_CLOUD_PROVIDER = "aws"
+
+  static final Bake SOME_BAKE_DETAILS = new Bake(id: SOME_JOB_ID, ami: SOME_AMI_ID, image_name: SOME_IMAGE_NAME)
+  static final BakeRequest SOME_BAKE_REQUEST = new BakeRequest(build_info_url: SOME_BUILD_INFO_URL, build_number: SOME_BUILD_NR)
+  static final BakeRecipe SOME_BAKE_RECIPE = new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
+
+  static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
+  static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM
+  static final BakeRequest.PackageType NUPKG_PACKAGE_TYPE = BakeRequest.PackageType.NUPKG
+
 
   def parseDebOsPackageNames(String packages) {
     PackageNameConverter.buildOsPackageNames(DEB_PACKAGE_TYPE, packages.tokenize(" "))


### PR DESCRIPTION
The motivation here is to enable Artifact decoration for bakes without altering current workflow. I've tried to write this in such a way that it's easy to make the bakeprovider more generic in the future. This also means I had to take some choices so feel free to weigh in. This change gives us the following output on the bake endpoint:


```
curl -s http://localhost:8087/api/v1/global/bake/e2f492f2-ee4e-4bc3-b2b8-f0e8179625c7 | jq .
{
  "id": "e2f492f2-ee4e-4bc3-b2b8-f0e8179625c7",
  "ami": null,
  "image_name": "myrepo/the-team/ah4234h",
  "artifact": {
    "name": "the-team/mycontainer",
    "type": "docker",
    "version": "1494232370153",
    "reference": "containers.schibsted.io/delivery-team/delivery-dash:ah4234h",
    "metadata": {
      "build_info_url": "https://travis-ci.org/mybuild/53",
      "build_number": "53"
    }
  }
}
```

WDYT?