### PR TITLE
chore(config): Switch to non-deprecated config & remove 12.04 from gce images

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -151,14 +151,6 @@ google:
   bakeryDefaults:
     baseImages:
     - baseImage:
-        id: precise
-        shortDescription: v12.04
-        detailedDescription: Ubuntu Precise Pangolin v12.04
-        packageType: deb
-        isImageFamily: true
-      virtualizationSettings:
-        sourceImageFamily: ubuntu-1204-lts
-    - baseImage:
         id: trusty
         shortDescription: v14.04
         detailedDescription: Ubuntu Trusty Tahr v14.04

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -234,59 +234,50 @@ google:
   # with SPINNAKER_GOOGLE_ENABLED or to explicitly set the property's value
   # to true.
   enabled: ${GOOGLE_ENABLED:false}
-  gce:
-    bakeryDefaults:
-      zone: us-central1-f
-      network: default
-      useInternalIp: false
-      templateFile: gce.json
-      baseImages:
-      # Either sourceImage or sourceImageFamily should be set. If both are set, sourceImage will take precedence.
-      # If you specify isImageFamily, deck will annotate the popup tooltip to indicate that the selected option
-      # represents an image family.
-      #
-      # This is an example of configuring a source image family:
-      # - baseImage:
-      #     id: precise
-      #     shortDescription: v12.04
-      #     detailedDescription: Ubuntu Precise Pangolin v12.04
-      #     packageType: deb
-      #     isImageFamily: true
-      #   virtualizationSettings:
-      #     sourceImageFamily: ubuntu-1204-lts
-      #
-      # This is an example of configuring an explicit source image, as opposed to a source image family:
-      # - baseImage:
-      #     id: precise
-      #     shortDescription: v12.04
-      #     detailedDescription: Ubuntu Precise Pangolin v12.04
-      #     packageType: deb
-      #   virtualizationSettings:
-      #     sourceImage: ubuntu-1204-precise-v20170110
-      - baseImage:
-          id: precise
-          shortDescription: v12.04
-          detailedDescription: Ubuntu Precise Pangolin v12.04
-          packageType: deb
-          isImageFamily: true
-        virtualizationSettings:
-          sourceImageFamily: ubuntu-1204-lts
-      - baseImage:
-          id: trusty
-          shortDescription: v14.04
-          detailedDescription: Ubuntu Trusty Tahr v14.04
-          packageType: deb
-          isImageFamily: true
-        virtualizationSettings:
-          sourceImageFamily: ubuntu-1404-lts
-      - baseImage:
-          id: xenial
-          shortDescription: v16.04
-          detailedDescription: Ubuntu Xenial Xerus v16.04
-          packageType: deb
-          isImageFamily: true
-        virtualizationSettings:
-          sourceImageFamily: ubuntu-1604-lts
+  bakeryDefaults:
+    zone: us-central1-f
+    network: default
+    useInternalIp: false
+    templateFile: gce.json
+    baseImages:
+    # Either sourceImage or sourceImageFamily should be set. If both are set, sourceImage will take precedence.
+    # If you specify isImageFamily, deck will annotate the popup tooltip to indicate that the selected option
+    # represents an image family.
+    #
+    # This is an example of configuring a source image family:
+    # - baseImage:
+    #     id: precise
+    #     shortDescription: v14.04
+    #     detailedDescription: Ubuntu Trusty Tahr v14.04
+    #     packageType: deb
+    #     isImageFamily: true
+    #   virtualizationSettings:
+    #     sourceImageFamily: ubuntu-1204-lts
+    #
+    # This is an example of configuring an explicit source image, as opposed to a source image family:
+    # - baseImage:
+    #     id: precise
+    #     shortDescription: v14.04
+    #     detailedDescription: Ubuntu Trusty Tahr v14.04
+    #     packageType: deb
+    #   virtualizationSettings:
+    #     sourceImage: ubuntu-1404-trusty-v20170517
+    - baseImage:
+        id: trusty
+        shortDescription: v14.04
+        detailedDescription: Ubuntu Trusty Tahr v14.04
+        packageType: deb
+        isImageFamily: true
+      virtualizationSettings:
+        sourceImageFamily: ubuntu-1404-lts
+    - baseImage:
+        id: xenial
+        shortDescription: v16.04
+        detailedDescription: Ubuntu Xenial Xerus v16.04
+        packageType: deb
+        isImageFamily: true
+      virtualizationSettings:
+        sourceImageFamily: ubuntu-1604-lts
 
 openstack:
   # The property referenced below, OS_ENABLED, is not set in the


### PR DESCRIPTION
@duftler because the images between `google.gce.bakeryDefaults.baseImages` and `google.bakeryDefaults.baseImages` are appended to one another, this shouldn't cause any images to be deleted -- unless -- if people have switched to the non-deprecated config (`google.bakeryDefaults.*`), and are depending on one of the three images listed in  `google.gce.bakeryDefaults.baseImages`, they will be overwritten because of how spring merges profiles. I'll check with our bigger users to see if this will affect them.