### PR TITLE
config(ami): Add Ubuntu 14.04 ami for us-east-2

### DIFF
--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -107,6 +107,11 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-9eaa1cf6
         sshUserName: ubuntu
+      - region: us-east-2
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-b69abcd3
+        sshUserName: ubuntu
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro


### PR DESCRIPTION
Update the default Rosco configuration to support Ubuntu 14.04 in us-east-2 on AWS.