### PR TITLE
inconsistent with BakeRequest.groovy

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -147,7 +147,7 @@ docker:
       virtualizationSettings:
         sourceImage: ubuntu:trusty
 
-google:
+gce:
   bakeryDefaults:
     baseImages:
     - baseImage:


### PR DESCRIPTION
com.netflix.spinnaker.rosco.api.BakeRequest.CloudProviderType use gce and I think its better than using google
