### PR TITLE
fix(bake/package/rpm): Added timestamp to yum repo name and file name

### DIFF
--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -57,9 +57,10 @@ function provision_rpm() {
   if [[ "$repository" != "" ]]; then
     IFS=';' read -ra repo <<< "$repository"
     for i in "${!repo[@]}"; do
+      ts=$(date +%s)
       cat > /tmp/spinnaker-$i.repo <<EOF
-[spinnaker-$i]
-name=spinnaker-$i
+[spinnaker-$ts-$i]
+name=spinnaker-$ts-$i
 baseurl=${repo[$i]}
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
This change resolves an issue where yum was not able to locate some packages if an image is being created from a previously baked image and both are using custom repositories. When a base image is created that included a repository, that repository was being named "spinnaker-0". As part of the base image generation, if "upgrade=true" is set, the yum cache will be updated and include the "spinnaker-0" repo in it's cache. When another image is created using that base image and includes it's own repository, the repository was also being named "spinnaker-0". This conflicts with the yum cache and if the 'repomd.xml' file that yum retrieves from the repo is older than the 'repomd.xml' that was cached when creating the base image, yum will ignore the file. This will potentially cause yum not to find the packages that are specified for the derived image.