### PR TITLE
chore(dependencies): Bump spinnaker-dependencies version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
   group = "com.netflix.spinnaker.rosco"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.109.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.109.2'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.rosco
 
+import com.netflix.spinnaker.config.ErrorConfiguration
 import com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
 import com.netflix.spinnaker.rosco.providers.docker.config.RoscoDockerConfiguration


### PR DESCRIPTION
Add an explicit import on @ErrorConfiguration to enable the
consistent exception handling that exists across other
Spinnaker services.
