### PR TITLE
chore(packer): Bump packer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test && \
   dpkg -i ./rosco-web/build/distributions/*.deb && \
   mkdir /packer && \
   cd /packer && \
-  wget https://releases.hashicorp.com/packer/0.12.1/packer_0.12.1_linux_amd64.zip && \
+  wget https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_linux_amd64.zip && \
   apt-get install unzip -y && \
-  unzip packer_0.12.1_linux_amd64.zip && \
+  unzip packer_1.1.0_linux_amd64.zip && \
   rm -rf /workdir
 
 ENV PATH "/packer:$PATH"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -9,9 +9,9 @@ COPY ./rosco-web/config/packer /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apk --nocache add --update bash wget  && \
-  wget https://releases.hashicorp.com/packer/0.12.1/packer_0.12.1_linux_amd64.zip && \
-  unzip packer_0.12.1_linux_amd64.zip && \
-  rm packer_0.12.1_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_linux_amd64.zip && \
+  unzip packer_1.1.0_linux_amd64.zip && \
+  rm packer_1.1.0_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,7 +12,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 install_packer() {
-  PACKER_VERSION="0.12.1"
+  PACKER_VERSION="1.1.0"
   local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then


### PR DESCRIPTION
I'm using the custom templates of packer to bakery my AMIs, and using the packer version installed with rosco, I receive the error below

Using the latest version of packer, it's works.

Could we bumping it?

I know that in the spinnaker/spinnker there is an script that install the packer too, so I going to update there if necessary.

<details>
==> amazon-chroot: AMI: ami-XXX

==> amazon-chroot: Waiting for AMI to become ready...

==> amazon-chroot: Deleting the created EBS volume...

Build 'amazon-chroot' errored: unexpected EOF

==> Some builds didn't complete successfully and had errors:
--> amazon-chroot: unexpected EOF

==> Builds finished but no artifacts were created.
panic: interface conversion: interface {} is nil, not map[string][]string
2017/10/18 18:16:42 packer: 
2017/10/18 18:16:42 packer: goroutine 113 [running]:
2017/10/18 18:16:42 packer: panic(0x13e6f60, 0xc420381f40)
2017/10/18 18:16:42 packer: 	/usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
2017/10/18 18:16:42 packer: github.com/mitchellh/packer/builder/amazon/common.(*StepAMIRegionCopy).Run(0xc420347b00, 0x1e117a0, 0xc420347a70, 0x0)
2017/10/18 18:16:42 packer: 	/Users/mwhooker/go/src/github.com/mitchellh/packer/builder/amazon/common/step_ami_region_copy.go:26 +0x8ff
2017/10/18 18:16:42 packer: github.com/mitchellh/packer/vendor/github.com/mitchellh/multistep.(*BasicRunner).Run(0xc4202f5f80, 0x1e117a0, 0xc420347a70)
2017/10/18 18:16:42 packer: 	/Users/mwhooker/go/src/github.com/mitchellh/packer/vendor/github.com/mitchellh/multistep/basic_runner.go:70 +0x207
2017/10/18 18:16:42 packer: github.com/mitchellh/packer/builder/amazon/chroot.(*Builder).Run(0xc42025a000, 0x1e140e0, 0xc4202fbb00, 0x1e0d0a0, 0xc420354cf0, 0x1e12e60, 0xc42007c420, 0xc42035e000, 0x0, 0x0, ...)
2017/10/18 18:16:42 packer: 	/Users/mwhooker/go/src/github.com/mitchellh/packer/builder/amazon/chroot/builder.go:275 +0xd7b
2017/10/18 18:16:42 packer: github.com/mitchellh/packer/packer/rpc.(*BuilderServer).Run(0xc42024eae0, 0x1, 0xc420358030, 0x0, 0x0)
2017/10/18 18:16:42 packer: 	/Users/mwhooker/go/src/github.com/mitchellh/packer/packer/rpc/builder.go:93 +0x218
2017/10/18 18:16:42 packer: reflect.Value.call(0xc4202828a0, 0xc420280078, 0x13, 0x15ffd31, 0x4, 0xc42038fed0, 0x3, 0x3, 0x0, 0x0, ...)
2017/10/18 18:16:42 packer: 	/usr/local/Cellar/go/1.7.3/libexec/src/reflect/value.go:434 +0x5c8
2017/10/18 18:16:42 packer: reflect.Value.Call(0xc4202828a0, 0xc420280078, 0x13, 0xc42038fed0, 0x3, 0x3, 0xc420312538, 0x1, 0x0)
2017/10/18 18:16:42 packer: 	/usr/local/Cellar/go/1.7.3/libexec/src/reflect/value.go:302 +0xa4
2017/10/18 18:16:42 packer: net/rpc.(*service).call(0xc4202506c0, 0xc420250680, 0xc4201e5928, 0xc420288700, 0xc4201b7760, 0x13117c0, 0xc42035802c, 0x18a, 0x12e6d00, 0xc420358030, ...)
2017/10/18 18:16:42 packer: 	/usr/local/Cellar/go/1.7.3/libexec/src/net/rpc/server.go:383 +0x148
2017/10/18 18:16:42 packer: created by net/rpc.(*Server).ServeCodec
2017/10/18 18:16:42 packer: 	/usr/local/Cellar/go/1.7.3/libexec/src/net/rpc/server.go:477 +0x421
2017/10/18 18:16:42 ui error: Build 'amazon-chroot' errored: unexpected EOF
2017/10/18 18:16:42 Builds completed. Waiting on interrupt barrier...
2017/10/18 18:16:42 machine readable: error-count []string{"1"}
2017/10/18 18:16:42 ui error: 
==> Some builds didn't complete successfully and had errors:
2017/10/18 18:16:42 machine readable: amazon-chroot,error []string{"unexpected EOF"}
2017/10/18 18:16:42 ui error: --> amazon-chroot: unexpected EOF
2017/10/18 18:16:42 ui: 
==> Builds finished but no artifacts were created.
2017/10/18 18:16:42 waiting for all plugin processes to complete...
2017/10/18 18:16:42 /usr/bin/packer: plugin process exited
2017/10/18 18:16:42 /usr/bin/packer: plugin process exited



!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Packer crashed! This is always indicative of a bug within Packer.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Packer[1] so that we can fix this.

[1]: https://github.com/mitchellh/packer/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
</details>




