### PR TITLE
fix(rosco): Revert Make pause_before configurable (#224)

### DIFF
--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -17,8 +17,7 @@
     "package_type": "",
     "packages": "",
     "upgrade": "",
-    "configDir": null,
-    "pause_before": "30s"
+    "configDir": null
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -50,6 +49,6 @@
       "packages={{user `packages`}}",
       "upgrade={{user `upgrade`}}"
     ],
-    "pause_before": "{{user `pause_before`}}"
+    "pause_before": "30s"
   }]
 }


### PR DESCRIPTION
This reverts commit 8f0564784f6a04631b7531c95cd876a93e4503d2.

Per this Packer issue `pause_before` isn't being expanded: https://github.com/hashicorp/packer/issues/5115