### PR TITLE
feat(bake) Added AWS spot pricing configuration when baking AMI's. Defaults to 'auto'.

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -13,26 +13,36 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-d4aed0bc
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-4f285a2f
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-59396769
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-8007b2e8
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-3a12605a
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: trusty
         shortDescription: v14.04
@@ -44,41 +54,57 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-9eaa1cf6
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-12512d72
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-3d50120d
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-central-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-87564feb
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-f95ef58a
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-98aa1cf0
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-59502c39
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-37501207
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: windows-2012-r2
         shortDescription: 2012 R2
@@ -92,6 +118,8 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-21414f36
         winRmUserName: Administrator
+        spotPrice: auto
+        spotPriceAutoProduct: Windows (Amazon VPC)
 
 azure:
   bakeryDefaults:

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -106,6 +106,14 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
       parameterMap.aws_winrm_username = awsVirtualizationSettings.winRmUserName
     }
 
+    if (awsVirtualizationSettings.spotPrice) {
+      parameterMap.aws_spot_price = awsVirtualizationSettings.spotPrice
+
+      if (awsVirtualizationSettings.spotPriceAutoProduct) {
+        parameterMap.aws_spot_price_auto_product = awsVirtualizationSettings.spotPriceAutoProduct
+      }
+    }
+
     if (awsBakeryDefaults.awsAccessKey && awsBakeryDefaults.awsSecretKey) {
       parameterMap.aws_access_key = awsBakeryDefaults.awsAccessKey
       parameterMap.aws_secret_key = awsBakeryDefaults.awsSecretKey

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
@@ -73,11 +73,12 @@ class RoscoAWSConfiguration {
     String sourceAmi
     String sshUserName
     String winRmUserName
+    String spotPrice
+    String spotPriceAutoProduct
   }
 
   @PostConstruct
   void init() {
     cloudProviderBakeHandlerRegistry.register(BakeRequest.CloudProviderType.aws, awsBakeHandler)
   }
-
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -64,14 +64,18 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
               virtualizationType: "hvm",
               instanceType: "t2.micro",
               sourceAmi: SOURCE_UBUNTU_HVM_IMAGE_NAME,
-              sshUserName: "ubuntu"
+              sshUserName: "ubuntu",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)"
             ],
             [
               region: REGION,
               virtualizationType: "pv",
               instanceType: "m3.medium",
               sourceAmi: SOURCE_UBUNTU_PV_IMAGE_NAME,
-              sshUserName: "ubuntu"
+              sshUserName: "ubuntu",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)"
             ]
           ]
         ],
@@ -86,7 +90,9 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
               virtualizationType: "hvm",
               instanceType: "t2.micro",
               sourceAmi: SOURCE_TRUSTY_HVM_IMAGE_NAME,
-              sshUserName: "ubuntu"
+              sshUserName: "ubuntu",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)"
             ]
           ]
         ],
@@ -101,7 +107,9 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
               virtualizationType: "hvm",
               instanceType: "t2.micro",
               sourceAmi: SOURCE_AMZN_HVM_IMAGE_NAME,
-              sshUserName: "ec2-user"
+              sshUserName: "ec2-user",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)"
             ]
           ]
         ],
@@ -117,7 +125,9 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
               virtualizationType: "hvm",
               instanceType: "t2.micro",
               sourceAmi: SOURCE_WINDOWS_2012_R2_HVM_IMAGE_NAME,
-              winRmUserName: "Administrator"
+              winRmUserName: "Administrator",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Windows (Amazon VPC)"
             ]
           ]
         ]
@@ -305,6 +315,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_region: REGION,
         aws_ssh_username: "ubuntu",
         aws_instance_type: "t2.micro",
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         aws_source_ami: SOURCE_UBUNTU_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
         repository: DEBIAN_REPOSITORY,
@@ -347,10 +359,12 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_AMZN_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: YUM_REPOSITORY,
         package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
-        configDir: configDir
+        configDir: configDir,
       ]
 
       @Subject
@@ -453,6 +467,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: "ami-12345678",
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -493,6 +509,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "m3.medium",
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -534,6 +552,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "m3.medium",
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -575,6 +595,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "m3.medium",
         aws_source_ami: SOURCE_UBUNTU_PV_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -617,6 +639,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -663,6 +687,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
@@ -707,6 +733,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_UBUNTU_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         repository: DEBIAN_REPOSITORY,
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
@@ -748,6 +776,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       aws_instance_type: "t2.micro",
       aws_source_ami: SOURCE_WINDOWS_2012_R2_HVM_IMAGE_NAME,
       aws_target_ami: targetImageName,
+      aws_spot_price: "auto",
+      aws_spot_price_auto_product: "Windows (Amazon VPC)",
       repository: CHOCOLATEY_REPOSITORY,
       package_type: NUPKG_PACKAGE_TYPE.util.packageType,
       packages: NUPKG_PACKAGES_NAME,
@@ -967,6 +997,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         repository: DEBIAN_REPOSITORY,
         packages: fullyQualifiedPackageName,
@@ -1021,6 +1053,8 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
         aws_instance_type: "t2.micro",
         aws_source_ami: SOURCE_TRUSTY_HVM_IMAGE_NAME,
         aws_target_ami: targetImageName,
+        aws_spot_price: "auto",
+        aws_spot_price_auto_product: "Linux/UNIX (Amazon VPC)",
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         repository: DEBIAN_REPOSITORY,
         packages: fullyQualifiedPackageName,

--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -11,6 +11,8 @@
     "aws_target_ami": null,
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "false",
+    "aws_spot_price": 0,
+    "aws_spot_price_auto_product": "",
     "appversion": "",
     "build_host": "",
     "repository": "",
@@ -33,6 +35,8 @@
     "ami_name": "{{user `aws_target_ami`}}",
     "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
     "ena_support": "{{user `aws_ena_support`}}",
+    "spot_price": "{{user `aws_spot_price`}}",
+    "spot_price_auto_product": "{{user `aws_spot_price_auto_product`}}",
     "tags": {
       "appversion": "{{user `appversion`}}",
       "build_host": "{{user `build_host`}}",

--- a/rosco-web/config/packer/aws-multi-ebs.json
+++ b/rosco-web/config/packer/aws-multi-ebs.json
@@ -11,6 +11,8 @@
     "aws_target_ami": null,
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "false",
+    "aws_spot_price": 0,
+    "aws_spot_price_auto_product": "",
     "appversion": "",
     "build_host": "",
     "repository": "",
@@ -67,6 +69,8 @@
     ],
     "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
     "ena_support": "{{user `aws_ena_support`}}",
+    "spot_price": "{{user `aws_spot_price`}}",
+    "spot_price_auto_product": "{{user `aws_spot_price_auto_product`}}",
     "tags": {
       "appversion": "{{user `appversion`}}",
       "build_host": "{{user `build_host`}}",

--- a/rosco-web/config/packer/aws-windows-2012-r2.json
+++ b/rosco-web/config/packer/aws-windows-2012-r2.json
@@ -12,6 +12,8 @@
     "aws_security_group": "",
     "aws_associate_public_ip_address": "false",
     "aws_ena_support": "false",
+    "aws_spot_price": 0,
+    "aws_spot_price_auto_product": "",
     "aws_userdata_file": "scripts/aws-windows.userdata",
     "appversion": "",
     "build_host": "",
@@ -48,6 +50,10 @@
       "security_group_id": "{{user `aws_security_group`}}",
 
       "subnet_id": "{{user `aws_subnet_id`}}",
+
+      "ena_support": "{{user `aws_ena_support`}},
+      "spot_price": "{{user `aws_spot_price`}}",
+      "spot_price_auto_product": "{{user `aws_spot_price_auto_product`}}",
 
       "tags": {
         "appversion": "{{user `appversion`}}",

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -56,6 +56,21 @@ aws:
     baseImages:
     # AMIs sourced from: https://cloud-images.ubuntu.com/locator/ec2/
     # Images should be considered placeholders.
+
+    # Packer Spot Pricing #
+    #   spotPrice specifies the maximum hourly price to pay for a spot instance to create the AMI.
+    #     This can be set to 'auto' to automatically discover the best spot price.
+    #     Set to "0" to use an on demand instance (default).
+    #   spotPriceAutoProduct is required if spotPrice is set to 'auto'.
+    #     This specifies what sort of AMI you're launching to find the best spot price.
+    #     This must be one of:
+    #        Linux/UNIX
+    #        Linux/UNIX (Amazon VPC)
+    #        SUSE Linux
+    #        SUSE Linux (Amazon VPC)
+    #        Windows
+    #        Windows (Amazon VPC)
+
     - baseImage:
         id: ubuntu
         shortDescription: v12.04
@@ -70,32 +85,44 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-d4aed0bc
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-4f285a2f
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-59396769
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-8007b2e8
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-3a12605a
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
 #      No exact equivalent available in us-west-2
 #      - region: us-west-2
 #        virtualizationType: pv
 #        instanceType: m3.medium
 #        sourceAmi:
 #        sshUserName: ubuntu
+#        spotPrice: auto
+#        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: trusty
         shortDescription: v14.04
@@ -109,46 +136,64 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-9d751ee7
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-7960481c
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-494c4829
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-e8cc6a90
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-central-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-aa30b8c5
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-fcb43185
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-a1701bdb
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-b84347d8
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-61cf6919
         sshUserName: ubuntu
+        spotPrice: auto
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: windows-2012-r2
         shortDescription: 2012 R2
@@ -162,6 +207,8 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-21414f36
         winRmUserName: Administrator
+        spotPrice: auto
+        spotPriceAutoProduct: Windows (Amazon VPC)
 
 
 azure:


### PR DESCRIPTION
Packer defaults to using on-demand pricing when creating AWS AMI's. Given that most bakes take considerably less than an hour, using on-demand pricing is wasteful since you pay for the full hour. This PR enables Packer to use spot pricing and defaults to 'auto' which allows Packer to automatically discover the best spot price. Setting 'spotPrice' to '0' (zero) causes Packer to use on-demand pricing.
