### PR TITLE
fix(rosco/log): Append to log instead of overwrite

### DIFF
--- a/rosco-web/etc/init/rosco.conf
+++ b/rosco-web/etc/init/rosco.conf
@@ -10,4 +10,4 @@ expect fork
 stop on stopping spinnaker
 
 env HOME=/home/spinnaker
-exec /opt/rosco/bin/rosco 2>&1 > /var/log/spinnaker/rosco/rosco.log &
+exec /opt/rosco/bin/rosco 2>&1 >> /var/log/spinnaker/rosco/rosco.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.