### PR TITLE
feat(bake) The addition of spot changed the defaults, swap them back

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -13,35 +13,35 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-d4aed0bc
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-4f285a2f
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-59396769
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-8007b2e8
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-3a12605a
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: trusty
@@ -54,56 +54,56 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-9eaa1cf6
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-12512d72
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-3d50120d
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-central-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-87564feb
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-f95ef58a
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-98aa1cf0
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-59502c39
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-37501207
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: windows-2012-r2
@@ -118,7 +118,7 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-21414f36
         winRmUserName: Administrator
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Windows (Amazon VPC)
 
 azure:

--- a/rosco-web/config/packer/aws-ebs.json
+++ b/rosco-web/config/packer/aws-ebs.json
@@ -11,7 +11,7 @@
     "aws_target_ami": null,
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "false",
-    "aws_spot_price": 0,
+    "aws_spot_price": "0",
     "aws_spot_price_auto_product": "",
     "appversion": "",
     "build_host": "",

--- a/rosco-web/config/packer/aws-multi-ebs.json
+++ b/rosco-web/config/packer/aws-multi-ebs.json
@@ -11,7 +11,7 @@
     "aws_target_ami": null,
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "false",
-    "aws_spot_price": 0,
+    "aws_spot_price": "0",
     "aws_spot_price_auto_product": "",
     "appversion": "",
     "build_host": "",

--- a/rosco-web/config/packer/aws-windows-2012-r2.json
+++ b/rosco-web/config/packer/aws-windows-2012-r2.json
@@ -12,7 +12,7 @@
     "aws_security_group": "",
     "aws_associate_public_ip_address": "false",
     "aws_ena_support": "false",
-    "aws_spot_price": 0,
+    "aws_spot_price": "0",
     "aws_spot_price_auto_product": "",
     "aws_userdata_file": "scripts/aws-windows.userdata",
     "appversion": "",

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -85,35 +85,35 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-d4aed0bc
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-4f285a2f
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-59396769
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-8007b2e8
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-3a12605a
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
 #      No exact equivalent available in us-west-2
 #      - region: us-west-2
@@ -121,7 +121,7 @@ aws:
 #        instanceType: m3.medium
 #        sourceAmi:
 #        sshUserName: ubuntu
-#        spotPrice: auto
+#        spotPrice: 0
 #        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: trusty
@@ -136,63 +136,63 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-9d751ee7
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-7960481c
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-494c4829
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-e8cc6a90
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-central-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-aa30b8c5
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: eu-west-1
         virtualizationType: hvm
         instanceType: t2.micro
         sourceAmi: ami-fcb43185
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-east-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-a1701bdb
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-1
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-b84347d8
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
       - region: us-west-2
         virtualizationType: pv
         instanceType: m3.medium
         sourceAmi: ami-61cf6919
         sshUserName: ubuntu
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
     - baseImage:
         id: windows-2012-r2
@@ -207,7 +207,7 @@ aws:
         instanceType: t2.micro
         sourceAmi: ami-21414f36
         winRmUserName: Administrator
-        spotPrice: auto
+        spotPrice: 0
         spotPriceAutoProduct: Windows (Amazon VPC)
 
 


### PR DESCRIPTION
A change was made to rosco recently to add the ability to use spot instances when baking. In the process it also changed spot to be the default. The functionality itself is fantastic, but defaulting to spot actually comes along with a few additional requirements. That causes bakes to start failing on update. So defaulting to the same bake style as we had in 0.102.0 and before, but leaving all the options there so users can turn spot on.

- Change the spotPrice default in the virtualizationSettings to 0 instead of auto. Set to auto it was defaulting to doing bakes using spot, which is a big change from the way we have been operating.
- Need to quote the spot price in the templates, otherwise packer throws an error with "expected type 'string', got unconvertible type 'float64'"
- Leave the spotPriceAutoProduct set in the virtualization settings, so users can set just aws_spot_price in their bake stage and have it work as expected.