### PR TITLE
chore(build): add debug flag to rosco build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ docker run -it --link redis:redis --rm redis redis-cli -h redis -p 6379
 ./gradlew bootRun
 ```
 
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8187.  The JVM will _not_ wait for the debugger
+to be attached before starting Rosco; the relevant JVM arguments can be seen and modified as needed in `build.gradle`.
+
 ## Verifying
 ```
 curl -v localhost:8087/bakeOptions

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ allprojects {
       exceptionFormat = 'full'
     }
   }
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8187'
+    }
+  }
 }
 
 defaultTasks ':rosco-web:bootRun'


### PR DESCRIPTION
Starting rosco with ./gradlew -DDEBUG=true now causes the JVM to
listen for a remote debugger on port 8187.
them.
