### PR TITLE
fix(bake): Fix broken AWS Windows bake script

### DIFF
--- a/rosco-web/config/packer/aws-windows-2012-r2.json
+++ b/rosco-web/config/packer/aws-windows-2012-r2.json
@@ -51,7 +51,7 @@
 
       "subnet_id": "{{user `aws_subnet_id`}}",
 
-      "ena_support": "{{user `aws_ena_support`}},
+      "ena_support": "{{user `aws_ena_support`}}",
       "spot_price": "{{user `aws_spot_price`}}",
       "spot_price_auto_product": "{{user `aws_spot_price_auto_product`}}",
 


### PR DESCRIPTION
The current aws-windows-2012-r2.json Packer script is malformed, causing
all bakes of AWS Windows AMIs to fail if they are using the default bake
script.  https://github.com/spinnaker/spinnaker/issues/2598