### PR TITLE
feat(artifacts): Update GCE bake to send image reference

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -113,10 +113,9 @@ abstract class CloudProviderBakeHandler {
   def Artifact produceArtifactDecorationFrom(BakeRequest bakeRequest, BakeRecipe bakeRecipe, Bake bakeDetails, String cloudProvider, String region) {
     Artifact bakedArtifact = new Artifact(
       name: bakeRecipe?.name,
-      version: bakeRecipe?.version,
       type: "${cloudProvider}/image",
       location: region,
-      reference: bakeDetails.ami ?: bakeDetails.image_name,
+      reference: getArtifactReference(bakeRequest, bakeDetails),
       metadata: [
         build_info_url: bakeRequest?.build_info_url,
         build_number: bakeRequest?.build_number
@@ -125,6 +124,10 @@ abstract class CloudProviderBakeHandler {
     )
 
     return bakedArtifact
+  }
+
+  def String getArtifactReference(BakeRequest bakeRequest, Bake bakeDetails) {
+    return bakeDetails.ami ?: bakeDetails.image_name
   }
 
   /**

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -174,4 +174,18 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
     return managedGoogleAccount
   }
 
+  @Override
+  def String getArtifactReference(BakeRequest bakeRequest, Bake bakeDetails) {
+    RoscoGoogleConfiguration.ManagedGoogleAccount managedGoogleAccount = resolveAccount(bakeRequest)
+    def project = managedGoogleAccount.getProject()
+    def imageName = bakeDetails.image_name
+
+    // TODO(ezimanyi): Remove hard-coding of image URI
+    // Either get packer to directly return the generated URI (preferred) or send a request to
+    // clouddriver to convert the project/image combination into a URI using the Google compute API
+    def uri = "https://www.googleapis.com/compute/v1/projects/$project/global/images/$imageName"
+    return uri
+  }
+
+
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -175,7 +175,7 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
   }
 
   @Override
-  def String getArtifactReference(BakeRequest bakeRequest, Bake bakeDetails) {
+  String getArtifactReference(BakeRequest bakeRequest, Bake bakeDetails) {
     RoscoGoogleConfiguration.ManagedGoogleAccount managedGoogleAccount = resolveAccount(bakeRequest)
     def project = managedGoogleAccount.getProject()
     def imageName = bakeDetails.image_name
@@ -183,9 +183,6 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
     // TODO(ezimanyi): Remove hard-coding of image URI
     // Either get packer to directly return the generated URI (preferred) or send a request to
     // clouddriver to convert the project/image combination into a URI using the Google compute API
-    def uri = "https://www.googleapis.com/compute/v1/projects/$project/global/images/$imageName"
-    return uri
+    return "https://www.googleapis.com/compute/v1/projects/$project/global/images/$imageName"
   }
-
-
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
@@ -29,7 +29,7 @@ class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults
     setup:
       def expectedArtifact = new Artifact (
         name: SOME_BAKE_RECIPE.name,
-        version: SOME_BAKE_RECIPE.version,
+        version: null,
         location: SOME_REGION,
         type: "${SOME_CLOUD_PROVIDER}/image",
         reference: SOME_BAKE_DETAILS.ami,
@@ -64,8 +64,8 @@ class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults
     where:
       bakeRequest       | bakeRecipe       | expectedName          | expectedVersion      | expectedReference | expectedMetadata
       null              | null             | null                  | null                 | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
-      null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | SOME_APP_VERSION_STR | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
-      SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | SOME_APP_VERSION_STR | SOME_AMI_ID       | ["build_info_url": SOME_BUILD_INFO_URL, "build_number": SOME_BUILD_NR]
+      null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
+      SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | ["build_info_url": SOME_BUILD_INFO_URL, "build_number": SOME_BUILD_NR]
 
   }
 


### PR DESCRIPTION
When baking a GCE image, set the reference of the produced artifact to the URI for the produced image