### PR TITLE
feat(bake/manifests): Rudimentary bake manifest support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
   group = "com.netflix.spinnaker.rosco"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.113.1'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.149.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -7,5 +7,6 @@ dependencies {
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency('jacksonGuava')
   compile spinnaker.dependency('jedis')
-  compile spinnaker.dependency("korkArtifacts")
+  compile spinnaker.dependency('korkWeb')
+  compile spinnaker.dependency('korkArtifacts')
 }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
@@ -26,13 +26,13 @@ import groovy.transform.Immutable
 @CompileStatic
 class JobRequest {
   List<String> tokenizedCommand
-  List<String> maskedPackerParameters = []
+  List<String> maskedParameters = []
   String jobId
 
   List<String> getMaskedTokenizedCommand() {
     return tokenizedCommand.collect { String masked ->
       String key = masked.split('=').first()
-      if (key && key in maskedPackerParameters) {
+      if (key && key in maskedParameters) {
         masked = "$key=******".toString()
       }
       return masked

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ClouddriverService.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ClouddriverService.java
@@ -1,0 +1,12 @@
+package com.netflix.spinnaker.rosco.services;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import retrofit.client.Response;
+import retrofit.http.Body;
+import retrofit.http.PUT;
+import retrofit.http.Query;
+
+public interface ClouddriverService {
+  @PUT("/artifacts/fetch/")
+  Response fetchArtifact(@Body Artifact artifact);
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ServiceConfig.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ServiceConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.services;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import retrofit.RestAdapter;
+import retrofit.client.OkClient;
+import retrofit.converter.JacksonConverter;
+
+@Configuration
+public class ServiceConfig {
+  @Value("${services.clouddriver.baseUrl:http://localhost:7002}")
+  String clouddriverBaseUrl;
+
+  @Value("${retrofit.logLevel:BASIC}")
+  String retrofitLogLevel;
+
+  // This should be service-agnostic if more integrations than clouddriver are used
+  @Bean
+  ClouddriverService clouddriverService() {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    return new RestAdapter.Builder()
+        .setEndpoint(clouddriverBaseUrl)
+        .setClient(new OkClient())
+        .setConverter(new JacksonConverter(objectMapper))
+        .setLogLevel(RestAdapter.LogLevel.valueOf(retrofitLogLevel))
+        .build()
+        .create(ClouddriverService.class);
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
@@ -71,7 +71,7 @@ class LocalJobFriendlyPackerCommandFactorySpec extends Specification implements 
 
     when:
       def packerCommand = packerCommandFactory.buildPackerCommand("", parameterMap, null, "")
-      def jobRequest = new JobRequest(tokenizedCommand: packerCommand, maskedPackerParameters: maskedPackerParameters, jobId: SOME_UUID)
+      def jobRequest = new JobRequest(tokenizedCommand: packerCommand, maskedParameters: maskedPackerParameters, jobId: SOME_UUID)
       def commandLine = new CommandLine(jobRequest.tokenizedCommand[0])
       def arguments = (String []) Arrays.copyOfRange(jobRequest.tokenizedCommand.toArray(), 1, jobRequest.tokenizedCommand.size())
       commandLine.addArguments(arguments, false)

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -28,9 +28,9 @@ trait TestDefaults {
   static final String SOME_CLOUD_PROVIDER = "aws"
   static final String SOME_REGION = "eu-west-1"
 
-  static final Bake SOME_BAKE_DETAILS = new Bake(id: SOME_JOB_ID, ami: SOME_AMI_ID, image_name: SOME_IMAGE_NAME)
-  static final BakeRequest SOME_BAKE_REQUEST = new BakeRequest(build_info_url: SOME_BUILD_INFO_URL, build_number: SOME_BUILD_NR)
-  static final BakeRecipe SOME_BAKE_RECIPE = new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
+  final Bake SOME_BAKE_DETAILS = new Bake(id: SOME_JOB_ID, ami: SOME_AMI_ID, image_name: SOME_IMAGE_NAME)
+  final BakeRequest SOME_BAKE_REQUEST = new BakeRequest(build_info_url: SOME_BUILD_INFO_URL, build_number: SOME_BUILD_NR)
+  final BakeRecipe SOME_BAKE_RECIPE = new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
 
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB
   static final BakeRequest.PackageType RPM_PACKAGE_TYPE = BakeRequest.PackageType.RPM

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -1,0 +1,5 @@
+dependencies {
+  compileOnly spinnaker.dependency("lombok")
+
+  compile project(":rosco-core")
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.rosco.manifests;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class BakeManifestRequest {
+  TemplateRenderer templateRenderer;
+  String outputName;
+  Artifact inputArtifact;
+  List<Artifact> values;
+  Map<String, Object> overrides;
+
+  public BakeRecipe convertToRecipe(TemplateUtils utils) {
+    return utils.buildBakeRecipe(this);
+  }
+
+  enum TemplateRenderer {
+    HELM2;
+
+    @JsonCreator
+    public TemplateRenderer fromString(String value) {
+      if (value == null) {
+        return null;
+      }
+
+      return Arrays.stream(values())
+          .filter(v -> value.equalsIgnoreCase(v.toString()))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("The value '" + value + "' is not a supported renderer"));
+    }
+  }
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestService.java
@@ -1,0 +1,64 @@
+package com.netflix.spinnaker.rosco.manifests;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.api.BakeStatus;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.jobs.JobExecutor;
+import com.netflix.spinnaker.rosco.jobs.JobRequest;
+import com.netflix.spinnaker.rosco.manifests.helm.HelmTemplateUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.UUID;
+
+@Component
+public class BakeManifestService {
+  @Autowired
+  HelmTemplateUtils helmTemplateUtils;
+
+  @Autowired
+  JobExecutor jobExecutor;
+
+  TemplateUtils templateUtils(BakeManifestRequest request) {
+    if (request.templateRenderer == null) {
+      throw new IllegalArgumentException("The request type must be set (e.g. helm2).");
+    }
+    switch (request.templateRenderer) {
+      case HELM2:
+        return helmTemplateUtils;
+      default:
+        throw new IllegalArgumentException("Request type " + request.templateRenderer + " is not supported.");
+    }
+  }
+
+  public Artifact bake(BakeManifestRequest request) {
+    TemplateUtils utils = templateUtils(request);
+    BakeRecipe recipe = utils.buildBakeRecipe(request);
+
+    JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString());
+    String jobId = jobExecutor.startJob(jobRequest);
+
+    BakeStatus bakeStatus = jobExecutor.updateJob(jobId);
+
+    while (bakeStatus == null || bakeStatus.getState() == BakeStatus.State.RUNNING) {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException ignored) {
+      }
+
+      bakeStatus = jobExecutor.updateJob(jobId);
+    }
+
+    if (bakeStatus.getResult() != BakeStatus.Result.SUCCESS) {
+      throw new IllegalStateException("Bake of " + request + " failed: " + bakeStatus.getLogsContent());
+    }
+
+    return Artifact.builder()
+        .type("embedded/base64")
+        .name(recipe.getName())
+        .reference(Base64.getEncoder().encodeToString(bakeStatus.getLogsContent().getBytes()))
+        .build();
+  }
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
@@ -1,0 +1,50 @@
+package com.netflix.spinnaker.rosco.manifests;
+
+import com.amazonaws.util.IOUtils;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.services.ClouddriverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+public abstract class TemplateUtils {
+  @Autowired
+  ClouddriverService clouddriverService;
+
+  public BakeRecipe buildBakeRecipe(BakeManifestRequest request) {
+    BakeRecipe result = new BakeRecipe();
+    result.setName(request.getOutputName());
+    return result;
+  }
+
+  private RetrySupport retrySupport = new RetrySupport();
+
+  private String nameFromReference(String reference) {
+    return reference.replace("/", "_")
+        .replace(":", "_");
+  }
+
+  public Path downloadArtifactToTmpFile(Artifact artifact) throws IOException {
+    Path path = Paths.get(System.getProperty("java.io.tmpdir"), nameFromReference(artifact.getReference()));
+    OutputStream outputStream = new FileOutputStream(path.toString());
+
+    Response response = retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
+
+    InputStream inputStream = response.getBody().in();
+    IOUtils.copy(inputStream, outputStream);
+    inputStream.close();
+    outputStream.close();
+
+    return path;
+  }
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -1,0 +1,36 @@
+package com.netflix.spinnaker.rosco.manifests.helm;
+
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
+import com.netflix.spinnaker.rosco.manifests.TemplateUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class HelmTemplateUtils extends TemplateUtils {
+  @Override
+  public BakeRecipe buildBakeRecipe(BakeManifestRequest request) {
+    BakeRecipe result = super.buildBakeRecipe(request);
+    Path templatePath;
+    try {
+      templatePath = downloadArtifactToTmpFile(request.getInputArtifact());
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to fetch helm template: " + e.getMessage(), e);
+    }
+
+    List<String> command = new ArrayList<>();
+    command.add("helm");
+    command.add("template");
+    command.add(templatePath.toString());
+    command.add("--name");
+    command.add(request.getOutputName());
+
+    result.setCommand(command);
+
+    return result;
+  }
+}

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -17,6 +17,7 @@ configurations.all {
 
 dependencies {
   compile project(":rosco-core")
+  compile project(":rosco-manifests")
   compile spinnaker.dependency("kork")
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency('korkStackdriver')

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.rosco
 
-import com.netflix.spinnaker.config.ErrorConfiguration
+import com.netflix.spinnaker.rosco.jobs.config.LocalJobConfig
 import com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
 import com.netflix.spinnaker.rosco.providers.docker.config.RoscoDockerConfiguration
 import com.netflix.spinnaker.rosco.providers.google.config.RoscoGoogleConfiguration
 import com.netflix.spinnaker.rosco.providers.openstack.config.RoscoOpenstackConfiguration
-import com.netflix.spinnaker.rosco.jobs.config.LocalJobConfig
+import com.netflix.spinnaker.rosco.services.ServiceConfig
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
@@ -45,11 +45,13 @@ import javax.servlet.Filter
   "com.netflix.spinnaker.rosco.executor",
   "com.netflix.spinnaker.rosco.filters",
   "com.netflix.spinnaker.rosco.jobs",
+  "com.netflix.spinnaker.rosco.manifests",
   "com.netflix.spinnaker.rosco.persistence",
   "com.netflix.spinnaker.config"
 ])
 @Import([
   WebConfig,
+  ServiceConfig,
   RoscoAWSConfiguration,
   RoscoAzureConfiguration,
   RoscoDockerConfiguration,

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
@@ -179,7 +179,7 @@ class BakeryController {
 
       def bakeRecipe = cloudProviderBakeHandler.produceBakeRecipe(region, bakeRequest)
       def jobRequest = new JobRequest(tokenizedCommand: bakeRecipe.command,
-                                      maskedPackerParameters: cloudProviderBakeHandler.maskedPackerParameters,
+                                      maskedParameters: cloudProviderBakeHandler.maskedPackerParameters,
                                       jobId: bakeRequest.request_id)
 
       if (bakeStore.acquireBakeLock(bakeKey)) {

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/V2BakeryController.java
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/V2BakeryController.java
@@ -1,0 +1,23 @@
+package com.netflix.spinnaker.rosco.controllers;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestService;
+import groovy.util.logging.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class V2BakeryController {
+  @Autowired
+  BakeManifestService bakeManifestService;
+
+  @RequestMapping(value = "/api/v2/manifest/bake", method = RequestMethod.POST)
+  Artifact doBake(@RequestBody BakeManifestRequest bakeRequest) {
+    return bakeManifestService.bake(bakeRequest);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'rosco'
 
-include 'rosco-core', 'rosco-web'
+include 'rosco-core', 'rosco-web', 'rosco-manifests'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
Still missing:

1. Downloading helm values files
2. Setting helm --set values
3. Deleting staged helm charts
4. Creating non base64 artifacts
5. Polling of running bake tasks -- the bake is currently synchronous

