### PR TITLE
chore(packer) - upgrade packer binary to 1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test && \
   dpkg -i ./rosco-web/build/distributions/*.deb && \
   mkdir /packer && \
   cd /packer && \
-  wget https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_linux_amd64.zip && \
+  wget https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2linux_amd64.zip && \
   apt-get install unzip -y && \
-  unzip packer_1.1.0_linux_amd64.zip && \
+  unzip packer_1.2.2_linux_amd64.zip && \
   rm -rf /workdir
 
 ENV PATH "/packer:$PATH"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -9,9 +9,9 @@ COPY ./rosco-web/config/packer /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apk --nocache add --update bash wget  && \
-  wget https://releases.hashicorp.com/packer/1.1.1/packer_1.1.1_linux_amd64.zip && \
-  unzip packer_1.1.1_linux_amd64.zip && \
-  rm packer_1.1.1_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip && \
+  unzip packer_1.2.2_linux_amd64.zip && \
+  rm packer_1.2.2_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 


### PR DESCRIPTION
Upgrades packer binary to 1.2.2 in both Docker and Docker.slim.

This PR addresses this issue here:
https://github.com/spinnaker/spinnaker/issues/2545
