### PR TITLE
feat(bake/artifacts): Pass artifacts to packer

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco.api
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.providers.util.PackageUtil
 import com.netflix.spinnaker.rosco.providers.util.packagespecific.DebPackageUtil
 import com.netflix.spinnaker.rosco.providers.util.packagespecific.NupkgPackageUtil
@@ -39,8 +40,10 @@ class BakeRequest {
   @ApiModelProperty(value = "A generated UUID which will be used to identify the effective packer bake", readOnly = true)
   final String request_id = UUID.randomUUID().toString()
   String user
-  @ApiModelProperty("The package(s) to install") @JsonProperty("package") @SerializedName("package")
+  @ApiModelProperty("The package(s) to install, as a space-delimited string") @JsonProperty("package") @SerializedName("package")
   String package_name
+  @ApiModelProperty("The package(s) to install, as Spinnaker artifacts")
+  List<Artifact> package_artifacts
   @ApiModelProperty("The CI server")
   String build_host
   @ApiModelProperty("The CI job")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
@@ -209,6 +209,7 @@ class BakePoller implements ApplicationListener<ContextRefreshedEvent> {
 
         if (cloudProviderBakeHandler) {
           String region = bakeStore.retrieveRegionById(bakeId)
+          cloudProviderBakeHandler.deleteArtifactFile(bakeId)
 
           if (region) {
             Bake bakeDetails = cloudProviderBakeHandler.scrapeCompletedBakeResults(region, bakeId, logsContent)

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -28,6 +28,10 @@ import com.netflix.spinnaker.rosco.providers.util.PackerCommandFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
 abstract class CloudProviderBakeHandler {
 
   @Value('${rosco.configDir}')
@@ -128,6 +132,16 @@ abstract class CloudProviderBakeHandler {
 
   def String getArtifactReference(BakeRequest bakeRequest, Bake bakeDetails) {
     return bakeDetails.ami ?: bakeDetails.image_name
+  }
+
+  Path getArtifactFilePath(String bakeId) {
+    Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"))
+    return tmpDir.resolve(bakeId + "-artifacts.json")
+  }
+
+  void deleteArtifactFile(String bakeId) {
+    Path artifactFile = getArtifactFilePath(bakeId)
+    Files.deleteIfExists(artifactFile)
   }
 
   /**

--- a/rosco-web/config/packer/gce.json
+++ b/rosco-web/config/packer/gce.json
@@ -17,7 +17,8 @@
     "packages": "",
     "upgrade": "",
     "configDir": null,
-    "manifestFile": null
+    "manifestFile": null,
+    "artifactFile": null
   },
   "builders": [{
     "type": "googlecompute",
@@ -36,17 +37,24 @@
     "use_internal_ip": "{{user `gce_use_internal_ip`}}",
     "image_description": "appversion: {{user `appversion`}}, build_host: {{user `build_host`}}, build_info_url: {{user `build_info_url`}}"
   }],
-  "provisioners": [{
-    "type": "shell",
-    "script": "{{user `configDir`}}/install_packages.sh",
-    "environment_vars": [
-      "repository={{user `repository`}}",
-      "package_type={{user `package_type`}}",
-      "packages={{user `packages`}}",
-      "upgrade={{user `upgrade`}}"
-    ],
-    "pause_before": "30s"
-  }],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "{{user `artifactFile`}}",
+      "destination": "/tmp/artifacts.json",
+      "pause_before": "30s"
+    },
+    {
+      "type": "shell",
+      "script": "{{user `configDir`}}/install_packages.sh",
+      "environment_vars": [
+        "repository={{user `repository`}}",
+        "package_type={{user `package_type`}}",
+        "packages={{user `packages`}}",
+        "upgrade={{user `upgrade`}}"
+      ]
+    }
+  ],
   "post-processors": [{
       "type": "manifest",
       "output": "{{user `manifestFile`}}"

--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -88,6 +88,10 @@ function main() {
   elif [[ "$package_type" == "rpm" ]]; then
     provision_rpm
   fi
+
+  if [[ -e "/tmp/artifacts.json" ]]; then
+    rm /tmp/artifacts.json
+  fi
 }
 
 main


### PR DESCRIPTION
Updates the rosco bake endpoint to accept a list of artifacts and passes these artifacts to packer.  Packer does not yet consume these artifacts, which will be implemented in a later pull request.