### PR TITLE
feat(bake/artifacts): Pass artifacts to packer

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco.api
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.providers.util.PackageUtil
 import com.netflix.spinnaker.rosco.providers.util.packagespecific.DebPackageUtil
 import com.netflix.spinnaker.rosco.providers.util.packagespecific.NupkgPackageUtil
@@ -39,8 +40,10 @@ class BakeRequest {
   @ApiModelProperty(value = "A generated UUID which will be used to identify the effective packer bake", readOnly = true)
   final String request_id = UUID.randomUUID().toString()
   String user
-  @ApiModelProperty("The package(s) to install") @JsonProperty("package") @SerializedName("package")
+  @ApiModelProperty("The package(s) to install, as a space-delimited string") @JsonProperty("package") @SerializedName("package")
   String package_name
+  @ApiModelProperty("The package(s) to install, as Spinnaker artifacts")
+  List<Artifact> package_artifacts
   @ApiModelProperty("The CI server")
   String build_host
   @ApiModelProperty("The CI job")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
@@ -209,6 +209,7 @@ class BakePoller implements ApplicationListener<ContextRefreshedEvent> {
 
         if (cloudProviderBakeHandler) {
           String region = bakeStore.retrieveRegionById(bakeId)
+          cloudProviderBakeHandler.deleteArtifactFile(bakeId)
 
           if (region) {
             Bake bakeDetails = cloudProviderBakeHandler.scrapeCompletedBakeResults(region, bakeId, logsContent)

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -131,6 +131,13 @@ abstract class CloudProviderBakeHandler {
   }
 
   /**
+   * Deletes the temporary file containing artifacts to bake into the image.  Currently only GCE
+   * supports baking artifacts, so this defaults to a no-op.
+   */
+  void deleteArtifactFile(String bakeId) {
+  }
+
+  /**
    * Finds the appropriate virtualization settings in this provider's configuration based on the region and
    * bake request parameters. Throws an IllegalArgumentException if the virtualization settings cannot be
    * found.

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.providers.CloudProviderBakeHandler
 import com.netflix.spinnaker.rosco.providers.google.config.RoscoGoogleConfiguration
 import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
+import com.netflix.spinnaker.rosco.providers.util.PackerArtifactService
 import com.netflix.spinnaker.rosco.providers.util.PackerManifest
 import com.netflix.spinnaker.rosco.providers.util.PackerManifestService
 import groovy.util.logging.Slf4j
@@ -37,6 +38,8 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
   private static resolvedBakeryDefaults = null
 
   ImageNameFactory imageNameFactory = new ImageNameFactory()
+
+  PackerArtifactService packerArtifactService = new PackerArtifactService()
 
   PackerManifestService packerManifestService = new PackerManifestService()
 
@@ -143,9 +146,16 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
       parameterMap.appversion = appVersionStr
     }
 
+    parameterMap.artifactFile = packerArtifactService.writeArtifactsToFile(bakeRequest.request_id, bakeRequest.package_artifacts)
+
     parameterMap.manifestFile = packerManifestService.getManifestFileName(bakeRequest.request_id)
 
     return parameterMap
+  }
+
+  @Override
+  void deleteArtifactFile(String bakeId) {
+    packerArtifactService.deleteArtifactFile(bakeId)
   }
 
   @Override

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -146,7 +146,7 @@ public class GCEBakeHandler extends CloudProviderBakeHandler {
       parameterMap.appversion = appVersionStr
     }
 
-    parameterMap.artifactFile = packerArtifactService.writeArtifactsToFile(bakeRequest.request_id, bakeRequest.package_artifacts)
+    parameterMap.artifactFile = packerArtifactService.writeArtifactsToFile(bakeRequest.request_id, bakeRequest.package_artifacts)?.toString()
 
     parameterMap.manifestFile = packerManifestService.getManifestFileName(bakeRequest.request_id)
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerArtifactService.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerArtifactService.java
@@ -32,7 +32,13 @@ public class PackerArtifactService {
   private Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
   private ObjectMapper objectMapper = new ObjectMapper();
 
-  public String writeArtifactsToFile(String bakeId, List<Artifact> artifacts) {
+  public PackerArtifactService() throws IOException {
+    if (!Files.isDirectory(tempDir)) {
+      Files.createDirectories(tempDir);
+    }
+  }
+
+  public Path writeArtifactsToFile(String bakeId, List<Artifact> artifacts) {
     Path artifactFile = getArtifactFilePath(bakeId);
 
     // If we were not passed any artifacts at all, write an empty array to the file rather
@@ -52,7 +58,7 @@ public class PackerArtifactService {
       throw new IllegalStateException("Could not write artifacts to file: " + e.getMessage());
     }
 
-    return artifactFile.toString();
+    return artifactFile;
   }
 
   public void deleteArtifactFile(String bakeId) {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerArtifactService.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerArtifactService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PackerArtifactService {
+
+  private Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  public String writeArtifactsToFile(String bakeId, List<Artifact> artifacts) {
+    Path artifactFile = getArtifactFilePath(bakeId);
+
+    // If we were not passed any artifacts at all, write an empty array to the file rather
+    // than null
+    if (artifacts == null) {
+      artifacts = new ArrayList<>();
+    }
+
+    try (
+        BufferedOutputStream artifactStream =
+            new BufferedOutputStream(
+              Files.newOutputStream(artifactFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+            )
+    ) {
+      objectMapper.writeValue(artifactStream, artifacts);
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not write artifacts to file: " + e.getMessage());
+    }
+
+    return artifactFile.toString();
+  }
+
+  public void deleteArtifactFile(String bakeId) {
+    Path artifactFile = getArtifactFilePath(bakeId);
+
+    try {
+      Files.deleteIfExists(artifactFile);
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not delete artifact file: " + e.getMessage());
+    }
+  }
+
+  private Path getArtifactFilePath(String bakeId) {
+    return tempDir.resolve(bakeId + "-artifacts.json");
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -33,6 +33,8 @@ import spock.lang.Subject
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.Paths
+
 class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
   private static final String REGION = "us-central1"
@@ -287,7 +289,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -335,7 +337,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -384,7 +386,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -433,7 +435,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
   }
@@ -484,7 +486,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -538,7 +540,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -589,7 +591,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -637,7 +639,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -688,7 +690,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -745,7 +747,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage], DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -795,7 +797,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -843,7 +845,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -892,7 +894,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -940,7 +942,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
 import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter
+import com.netflix.spinnaker.rosco.providers.util.PackerArtifactService
 import com.netflix.spinnaker.rosco.providers.util.PackerCommandFactory
 import com.netflix.spinnaker.rosco.providers.google.config.RoscoGoogleConfiguration
 import com.netflix.spinnaker.rosco.providers.google.config.RoscoGoogleConfiguration.GCEBakeryDefaults
@@ -41,6 +42,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
   private static final String SOURCE_YAKKETY_IMAGE_NAME = "some-yakkety-image"
   private static final String SOURCE_CENTOS_HVM_IMAGE_NAME = "some-centos-image"
   private static final String MANIFEST_FILE_NAME = "/path/to/stub-manifest.json"
+  private static final String ARTIFACT_FILE_NAME = "/path/to/stub-artifact.json"
 
   @Shared
   String configDir = "/some/path"
@@ -50,6 +52,9 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
 
   @Shared
   RoscoGoogleConfiguration.GoogleConfigurationProperties googleConfigurationProperties
+
+  @Shared
+  ObjectMapper objectMapper = new ObjectMapper()
 
   @Shared
   def gceBakeryDefaultsJson = [
@@ -243,6 +248,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -260,6 +266,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -269,6 +276,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -279,6 +287,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -287,6 +296,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -304,6 +314,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: RPM_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -313,6 +324,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          yumRepository: YUM_REPOSITORY)
 
@@ -323,6 +335,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -331,6 +344,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -349,6 +363,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -358,6 +373,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -368,6 +384,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -376,6 +393,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -394,6 +412,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -403,6 +422,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -413,6 +433,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
   }
@@ -421,6 +442,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -439,6 +461,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME,
         someAttr1: "someValue1",
         someAttr2: "someValue2"
@@ -450,6 +473,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -460,6 +484,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -468,6 +493,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -491,6 +517,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -500,6 +527,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -510,6 +538,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -518,6 +547,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -536,6 +566,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
       def gceBakeryDefaultsAugmented = gceBakeryDefaults.clone()
@@ -547,6 +578,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -557,6 +589,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -565,6 +598,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -582,6 +616,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -591,6 +626,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -601,6 +637,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -609,6 +646,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -629,6 +667,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -638,6 +677,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -648,6 +688,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -656,6 +697,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def fullyQualifiedPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
       def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
@@ -679,6 +721,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: fullyQualifiedPackageName,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME,
         appversion: appVersionStr,
         build_host: buildHost,
@@ -691,6 +734,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -701,6 +745,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage], DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -709,6 +754,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -728,6 +774,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -737,6 +784,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -747,6 +795,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -755,6 +804,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -772,6 +822,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -781,6 +832,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -791,6 +843,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -799,6 +852,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -817,6 +871,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -826,6 +881,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -836,6 +892,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
@@ -844,6 +901,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)
       def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def packerArtifactServiceMock = Mock(PackerArtifactService)
       def packerManifestServiceMock = Mock(PackerManifestService)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGES_NAME,
@@ -861,6 +919,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         package_type: DEB_PACKAGE_TYPE.util.packageType,
         packages: PACKAGES_NAME,
         configDir: configDir,
+        artifactFile: ARTIFACT_FILE_NAME,
         manifestFile: MANIFEST_FILE_NAME
       ]
 
@@ -870,6 +929,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
                                                          googleConfigurationProperties: googleConfigurationProperties,
                                                          imageNameFactory: imageNameFactoryMock,
                                                          packerCommandFactory: packerCommandFactoryMock,
+                                                         packerArtifactService: packerArtifactServiceMock,
                                                          packerManifestService: packerManifestServiceMock,
                                                          debianRepository: DEBIAN_REPOSITORY)
 
@@ -880,6 +940,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> ARTIFACT_FILE_NAME
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }

--- a/rosco-web/config/packer/gce.json
+++ b/rosco-web/config/packer/gce.json
@@ -17,7 +17,8 @@
     "packages": "",
     "upgrade": "",
     "configDir": null,
-    "manifestFile": null
+    "manifestFile": null,
+    "artifactFile": null
   },
   "builders": [{
     "type": "googlecompute",
@@ -36,17 +37,24 @@
     "use_internal_ip": "{{user `gce_use_internal_ip`}}",
     "image_description": "appversion: {{user `appversion`}}, build_host: {{user `build_host`}}, build_info_url: {{user `build_info_url`}}"
   }],
-  "provisioners": [{
-    "type": "shell",
-    "script": "{{user `configDir`}}/install_packages.sh",
-    "environment_vars": [
-      "repository={{user `repository`}}",
-      "package_type={{user `package_type`}}",
-      "packages={{user `packages`}}",
-      "upgrade={{user `upgrade`}}"
-    ],
-    "pause_before": "30s"
-  }],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "{{user `artifactFile`}}",
+      "destination": "/tmp/artifacts.json",
+      "pause_before": "30s"
+    },
+    {
+      "type": "shell",
+      "script": "{{user `configDir`}}/install_packages.sh",
+      "environment_vars": [
+        "repository={{user `repository`}}",
+        "package_type={{user `package_type`}}",
+        "packages={{user `packages`}}",
+        "upgrade={{user `upgrade`}}"
+      ]
+    }
+  ],
   "post-processors": [{
       "type": "manifest",
       "output": "{{user `manifestFile`}}"

--- a/rosco-web/config/packer/install_packages.sh
+++ b/rosco-web/config/packer/install_packages.sh
@@ -88,6 +88,10 @@ function main() {
   elif [[ "$package_type" == "rpm" ]]; then
     provision_rpm
   fi
+
+  if [[ -e "/tmp/artifacts.json" ]]; then
+    rm /tmp/artifacts.json
+  fi
 }
 
 main


### PR DESCRIPTION
Updates the rosco bake endpoint to accept a list of artifacts and passes these artifacts to packer.  Packer does not yet consume these artifacts, which will be implemented in a later pull request.