### PR TITLE
fix(kubernetes): --set multitple times does not work with exe

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -44,11 +44,13 @@ public class HelmTemplateUtils extends TemplateUtils {
     command.add(request.getOutputName());
 
     Map<String, Object> overrides = request.getOverrides();
-    if (overrides != null) {
-      for (Map.Entry<String, Object> entry : overrides.entrySet()) {
-        command.add("--set");
-        command.add("'" + entry.getKey() + "=" + entry.getValue().toString() + "'");
-      }
+    if (!overrides.isEmpty()) {
+        List<String> overrideList = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : overrides.entrySet()) {
+            overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
+        }
+        command.add("--set-string");
+        command.add(overrideList.stream().collect(Collectors.joining(",")));
     }
 
     if (!valuePaths.isEmpty()) {


### PR DESCRIPTION
The `--set` command added multiple times does not get honored in the `org.apache.commons.exec.CommandLine` when getting executed. Instead we can use `--set-string` to concat all of the values together like `--values`