### PR TITLE
chore(packer) : upgrade packer binary to 1.2.2

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,7 +12,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 install_packer() {
-  PACKER_VERSION="1.1.0"
+  PACKER_VERSION="1.2.2"
   local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then


### PR DESCRIPTION
Upgrades packer binary to 1.2.2 in `rosco-web/pkg_scripts/postInstall.sh`.

I found Docker's packer was already upgraded, but not `postInstall.sh`.
refs https://github.com/spinnaker/rosco/pull/244

This PR addresses this issue here:
https://github.com/spinnaker/spinnaker/issues/2545
