### PR TITLE
fix(bake/chocolatey): Observe Chocolatey exit codes

### DIFF
--- a/rosco-web/config/packer/scripts/windows-install-packages.ps1
+++ b/rosco-web/config/packer/scripts/windows-install-packages.ps1
@@ -95,6 +95,10 @@ function Install-AllPackages($packageNames){
       else {
         &"choco" install $packageName --yes
       }
+      
+      if ($LastExitCode -ne 0) {
+        exit $LastExitCode
+      }
     }
 }
 


### PR DESCRIPTION
Currently, when installing multiple packages, all are installs are attempted and only the final exit code is used (it falls through to Packer scripts in $LastExitCode).  Instead, exit with the same exit code as soon as the first package install fails.

