### PR TITLE
feat(bake/windows): Allow Chocolatey version control via attributes

### DIFF
--- a/rosco-web/config/packer/aws-windows-2012-r2.json
+++ b/rosco-web/config/packer/aws-windows-2012-r2.json
@@ -21,7 +21,8 @@
     "package_type": "",
     "packages": "",
     "upgrade": "",
-    "configDir": null
+    "configDir": null,
+    "chocolateyVersion": ""
   },
 
   "builders": [
@@ -76,7 +77,8 @@
         "repository={{user `repository`}}",
         "package_type={{user `package_type`}}",
         "packages={{user `packages`}}",
-        "upgrade={{user `upgrade`}}"
+        "upgrade={{user `upgrade`}}",
+        "chocolateyVersion={{user `chocolateyVersion`}}"
       ],
       "pause_before": "30s"
     }

--- a/rosco-web/config/packer/azure-windows-2012-r2.json
+++ b/rosco-web/config/packer/azure-windows-2012-r2.json
@@ -19,7 +19,8 @@
     "package_type": "",
     "packages": "",
     "upgrade": "",
-    "configDir": null
+    "configDir": null,
+    "chocolateyVersion": ""
   },
   "builders": [{
     "type": "azure-arm",
@@ -62,7 +63,8 @@
         "repository={{user `repository`}}",
         "package_type={{user `package_type`}}",
         "packages={{user `packages`}}",
-        "upgrade={{user `upgrade`}}"
+        "upgrade={{user `upgrade`}}",
+        "chocolateyVersion={{user `chocolateyVersion`}}"
       ],
       "pause_before": "30s"
     }


### PR DESCRIPTION
The current Chocolatey scripts always use the latest version, meaning
that bugs in new releases of Chocolatey may affect Windows bakes. This
pull allows a "chocolateyVersion" attribute to be applied to a bake step
to manually control the version installed by the scripts.

Default behavior is unchanged, it will install the latest version.