### PR TITLE
fix(bakery/oracle): add private key passphrase

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandler.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandler.java
@@ -103,6 +103,7 @@ public class OCIBakeHandler extends CloudProviderBakeHandler {
         put("oracle_user_id", managedAccount.getUserId());
         put("oracle_fingerprint", managedAccount.getFingerprint());
         put("oracle_ssh_private_key_file_path", managedAccount.getSshPrivateKeyFilePath());
+        put("oracle_pass_phrase", managedAccount.getPrivateKeyPassphrase());
         put("oracle_region", managedAccount.getRegion());
         put("oracle_availability_domain", oracleBakeryDefaults.getAvailabilityDomain());
         put("oracle_instance_shape", oracleBakeryDefaults.getInstanceShape());

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/oracle/config/ManagedOracleAccount.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/oracle/config/ManagedOracleAccount.java
@@ -15,6 +15,7 @@ public class ManagedOracleAccount {
   private String userId;
   private String fingerprint;
   private String sshPrivateKeyFilePath;
+  private String privateKeyPassphrase;
   private String tenancyId;
   private String region;
 
@@ -48,6 +49,14 @@ public class ManagedOracleAccount {
 
   public void setSshPrivateKeyFilePath(String sshPrivateKeyFilePath) {
     this.sshPrivateKeyFilePath = sshPrivateKeyFilePath;
+  }
+
+  public String getPrivateKeyPassphrase() {
+    return privateKeyPassphrase;
+  }
+
+  public void setPrivateKeyPassphrase(String privateKeyPassphrase) {
+    this.privateKeyPassphrase = privateKeyPassphrase;
   }
 
   public String getTenancyId() {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandlerSpec.groovy
@@ -75,6 +75,7 @@ class OCIBakeHandlerSpec extends Specification implements TestDefaults {
           userId: "ocid1.user.oc1..user",
           fingerprint: "myfingerprint",
           sshPrivateKeyFilePath: "mysshPrivateKeyFilePath",
+          privateKeyPassphrase: "mypassphrase",
           tenancyId: "ocid1.tenancy.oc1..tenancy",
           region: "us-ashburn-1"
         ],
@@ -84,6 +85,7 @@ class OCIBakeHandlerSpec extends Specification implements TestDefaults {
           userId: "userId2",
           fingerprint: "fingerprint2",
           sshPrivateKeyFilePath: "sshPrivateKeyFilePath2",
+          privateKeyPassphrase: "mypassphrase2",
           tenancyId: "tenancyId2",
           region: "region2"
         ]
@@ -157,6 +159,7 @@ class OCIBakeHandlerSpec extends Specification implements TestDefaults {
       oracle_user_id: oracleConfigurationProperties.accounts.get(accountIndex).userId,
       oracle_fingerprint: oracleConfigurationProperties.accounts.get(accountIndex).fingerprint,
       oracle_ssh_private_key_file_path: oracleConfigurationProperties.accounts.get(accountIndex).sshPrivateKeyFilePath,
+      oracle_pass_phrase: oracleConfigurationProperties.accounts.get(accountIndex).privateKeyPassphrase,
       oracle_region: oracleConfigurationProperties.accounts.get(accountIndex).region,
       oracle_availability_domain: oracleBakeryDefaults.availabilityDomain,
       oracle_subnet_id: oracleBakeryDefaults.subnetId,

--- a/rosco-web/config/packer/oci.json
+++ b/rosco-web/config/packer/oci.json
@@ -12,6 +12,7 @@
     "oracle_user_id": null,
     "oracle_fingerprint": null,
     "oracle_ssh_private_key_file_path": null,
+    "oracle_pass_phrase": null,
 
     "appversion": "",
     "build_host": "",
@@ -36,7 +37,8 @@
       "tenancy_ocid": "{{user `oracle_tenancy_id`}}",
       "user_ocid": "{{user `oracle_user_id`}}",
       "fingerprint": "{{user `oracle_fingerprint`}}",
-      "key_file": "{{user `oracle_ssh_private_key_file_path`}}"
+      "key_file": "{{user `oracle_ssh_private_key_file_path`}}",
+      "pass_phrase": "{{user `oracle_pass_phrase`}}"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Allow oracle bakery to use private key file with passphrase.