### PR TITLE
fix(bakery/oracle): private key passphrase is optional

### DIFF
--- a/rosco-web/config/packer/oci.json
+++ b/rosco-web/config/packer/oci.json
@@ -12,7 +12,7 @@
     "oracle_user_id": null,
     "oracle_fingerprint": null,
     "oracle_ssh_private_key_file_path": null,
-    "oracle_pass_phrase": null,
+    "oracle_pass_phrase": "",
 
     "appversion": "",
     "build_host": "",


### PR DESCRIPTION
packer variable oracle_pass_phrase should be optional, not required.