### PR TITLE
fix(packer): Fix spot pricing flags

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -108,10 +108,10 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
 
     if (awsVirtualizationSettings.spotPrice) {
       parameterMap.aws_spot_price = awsVirtualizationSettings.spotPrice
+    }
 
-      if (awsVirtualizationSettings.spotPriceAutoProduct) {
-        parameterMap.aws_spot_price_auto_product = awsVirtualizationSettings.spotPriceAutoProduct
-      }
+    if (awsVirtualizationSettings.spotPrice == "auto" && awsVirtualizationSettings.spotPriceAutoProduct) {
+      parameterMap.aws_spot_price_auto_product = awsVirtualizationSettings.spotPriceAutoProduct
     }
 
     if (awsBakeryDefaults.awsAccessKey && awsBakeryDefaults.awsSecretKey) {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -624,40 +624,40 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
 
   void 'sends spot_price_auto_product iff spot_price is set to auto'() {
     setup:
-    def imageNameFactoryMock = Mock(ImageNameFactory)
-    def packerCommandFactoryMock = Mock(PackerCommandFactory)
-    def bakeRequest = new BakeRequest()
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest()
 
-    @Subject
-    AWSBakeHandler awsBakeHandler = new AWSBakeHandler(configDir: configDir,
-            awsBakeryDefaults: awsBakeryDefaults,
-            imageNameFactory: imageNameFactoryMock,
-            packerCommandFactory: packerCommandFactoryMock,
-            debianRepository: DEBIAN_REPOSITORY)
-
-    when:
-    def virtualizationSettings = [
-            region: "us-east-1",
-            spotPrice: "0",
-            spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
-    ]
-    def parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
-
-    then:
-    parameterMap.aws_spot_price == "0"
-    !parameterMap.containsValue("aws_spot_price_auto_product")
+      @Subject
+      AWSBakeHandler awsBakeHandler = new AWSBakeHandler(configDir: configDir,
+                                                         awsBakeryDefaults: awsBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
 
     when:
-    virtualizationSettings = [
-            region: "us-east-1",
-            spotPrice: "auto",
-            spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
-    ]
-    parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
+      def virtualizationSettings = [
+              region: "us-east-1",
+              spotPrice: "0",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
+      ]
+      def parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
 
     then:
-    parameterMap.aws_spot_price == "auto"
-    parameterMap.aws_spot_price_auto_product == "Linux/UNIX (Amazon VPC)"
+      parameterMap.aws_spot_price == "0"
+      !parameterMap.containsValue("aws_spot_price_auto_product")
+
+    when:
+      virtualizationSettings = [
+              region: "us-east-1",
+              spotPrice: "auto",
+              spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
+      ]
+      parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
+
+    then:
+      parameterMap.aws_spot_price == "auto"
+      parameterMap.aws_spot_price_auto_product == "Linux/UNIX (Amazon VPC)"
   }
 
   void 'produces packer command with all required parameters for trusty, using explicit vm type'() {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -622,6 +622,44 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
+  void 'sends spot_price_auto_product iff spot_price is set to auto'() {
+    setup:
+    def imageNameFactoryMock = Mock(ImageNameFactory)
+    def packerCommandFactoryMock = Mock(PackerCommandFactory)
+    def bakeRequest = new BakeRequest()
+
+    @Subject
+    AWSBakeHandler awsBakeHandler = new AWSBakeHandler(configDir: configDir,
+            awsBakeryDefaults: awsBakeryDefaults,
+            imageNameFactory: imageNameFactoryMock,
+            packerCommandFactory: packerCommandFactoryMock,
+            debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+    def virtualizationSettings = [
+            region: "us-east-1",
+            spotPrice: "0",
+            spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
+    ]
+    def parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
+
+    then:
+    parameterMap.aws_spot_price == "0"
+    !parameterMap.containsValue("aws_spot_price_auto_product")
+
+    when:
+    virtualizationSettings = [
+            region: "us-east-1",
+            spotPrice: "auto",
+            spotPriceAutoProduct: "Linux/UNIX (Amazon VPC)",
+    ]
+    parameterMap = awsBakeHandler.buildParameterMap(REGION, virtualizationSettings, "", bakeRequest, "")
+
+    then:
+    parameterMap.aws_spot_price == "auto"
+    parameterMap.aws_spot_price_auto_product == "Linux/UNIX (Amazon VPC)"
+  }
+
   void 'produces packer command with all required parameters for trusty, using explicit vm type'() {
     setup:
       def imageNameFactoryMock = Mock(ImageNameFactory)


### PR DESCRIPTION
Packer 1.3 now enforces that aws_spot_price_auto_product can only be passed if aws_spot_price is set to "auto". The default settings that ship with Spinnaker set aws_spot_price to "0" and aws_spot_price_auto_product non-null. Gate passing through the product value so that it is only passed through if the spot price is "auto".