### PR TITLE
fix(packer): Determine image name from unencrypted AMI log line

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component
 public class AWSBakeHandler extends CloudProviderBakeHandler {
 
   private static final String IMAGE_NAME_TOKEN = "amazon-(chroot|ebs): Creating the AMI:"
+  private static final String UNENCRYPTED_IMAGE_NAME_TOKEN = "(==> |)amazon-(chroot|ebs): Creating unencrypted AMI"
 
   ImageNameFactory imageNameFactory = new ImageNameFactory()
 
@@ -161,6 +162,9 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
     logsContent.eachLine { String line ->
       if (line =~ IMAGE_NAME_TOKEN) {
         imageName = line.split(" ").last()
+      } else if (line =~ UNENCRYPTED_IMAGE_NAME_TOKEN) {
+        line = line.replaceAll(UNENCRYPTED_IMAGE_NAME_TOKEN, "").trim()
+        imageName = line.split(" ").first()
       } else if (line =~ "$region:") {
         amiId = line.split(" ").last()
       }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -171,6 +171,38 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       }
   }
 
+  void 'can scrape packer 1.3+ logs for unencrypted image name'() {
+    setup:
+    @Subject
+    AWSBakeHandler awsBakeHandler = new AWSBakeHandler(awsBakeryDefaults: awsBakeryDefaults)
+
+    when:
+    def logsContent =
+      "==> amazon-ebs: Creating unencrypted AMI test-ami-123456789_123456789 from instance i-123456789\n" +
+      "    amazon-ebs: AMI: ami-2c014644\n" +
+      "==> amazon-ebs: Waiting for AMI to become ready...\n" +
+      "==> amazon-ebs: Terminating the source AWS instance...\n" +
+      "==> amazon-ebs: Cleaning up any extra volumes...\n" +
+      "==> amazon-ebs: No volumes to clean up, skipping\n" +
+      "==> amazon-ebs: Deleting temporary security group...\n" +
+      "==> amazon-ebs: Deleting temporary keypair...\n" +
+      "Build 'amazon-ebs' finished.\n" +
+      "\n" +
+      "==> Builds finished. The artifacts of successful builds are:\n" +
+      "--> amazon-ebs: AMIs were created:\n" +
+      "\n" +
+      "us-east-1: ami-2c014644"
+
+    Bake bake = awsBakeHandler.scrapeCompletedBakeResults(REGION, "123", logsContent)
+
+    then:
+    with (bake) {
+      id == "123"
+      ami == "ami-2c014644"
+      image_name == "test-ami-123456789_123456789"
+    }
+  }
+
   void 'can scrape packer (amazon-chroot) logs for image name'() {
     setup:
       @Subject


### PR DESCRIPTION
@duftler 

We upgraded to Packer 1.3+ (1.3.3, specifically) and the line with the AMI name changed.  This accounts for that change.  Not entirely thrilled about this, but it works and follows the current pattern.

Merge it if you like, or leave it here just for posterity - either way we're using it in our own deploy.  I think ultimately resolving this issue the way @duftler outlined in the TODO comment is the way to go.
