### PR TITLE
config(provider/azure): update the image base vm size in packer

### DIFF
--- a/rosco-web/config/packer/azure-linux.json
+++ b/rosco-web/config/packer/azure-linux.json
@@ -36,7 +36,7 @@
     "image_sku": "{{user `azure_image_sku`}}",
 
     "location": "{{user `azure_location`}}",
-    "vm_size": "Standard_A2"
+    "vm_size": "Standard_DS2_v2"
   }],
   "provisioners": [{
     "type": "shell",


### PR DESCRIPTION
Per shared knowledge from Azure Compute team, using VM size "DS2 v2" could greatly improve the performance of Azure VM provision and de-provision by using packer in the bake stage. We've tested it in our local dev Spinnaker environment and it was true.

Need to mention that the $ cost of the new size is a little bit more expensive than the original one. But making this change is definitely not for charging more money but out of the consideration of improving performance. In addition, the charge diff between this two sizes is about 0.05 USD/hour for [Linux ](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/) and 0.1 USD/hour for [Windows](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/), while given the bake-image action could be finished in minutes and after that the temporarily created VM will be deleted with no more charge, so we regard this diff of charge is acceptable.