### PR TITLE
feat(manifests): jinja manifest rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   ./get && \
   rm get
 
+RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install jinja2-cli --upgrade
+
 ENV PATH "/packer:$PATH"
 
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -20,6 +20,10 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   ./get && \
   rm get
 
+RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install jinja2-cli --upgrade
+
 RUN adduser -D -S spinnaker
 
 USER spinnaker

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
@@ -17,7 +17,8 @@ public class BakeManifestRequest {
   Map<String, Object> overrides;
 
   public enum TemplateRenderer {
-    HELM2;
+    HELM2,
+    JINJA2;
 
     @JsonCreator
     public TemplateRenderer fromString(String value) {

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Armory
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.rosco.manifests.jinja;
+package com.netflix.spinnaker.rosco.manifests;
 
-import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-public class JinjaBakeManifestRequest extends BakeManifestRequest {
-  public String inputFormat = "yaml";
+import java.util.Map;
+
+public interface BakeManifestService {
+  Artifact bake(Map<String, Object> bakeManifestRequest);
+  boolean handles(String type);
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -1,46 +1,41 @@
 package com.netflix.spinnaker.rosco.manifests.helm;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.api.BakeStatus;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.jobs.JobExecutor;
 import com.netflix.spinnaker.rosco.jobs.JobRequest;
-import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
-import com.netflix.spinnaker.rosco.manifests.TemplateUtils;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestService;
 import com.netflix.spinnaker.rosco.manifests.TemplateUtils.BakeManifestEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Map;
 import java.util.UUID;
 
 @Component
-public class HelmBakeManifestService {
+public class HelmBakeManifestService implements BakeManifestService {
   @Autowired
   HelmTemplateUtils helmTemplateUtils;
 
   @Autowired
   JobExecutor jobExecutor;
 
-  HelmTemplateUtils templateUtils(HelmBakeManifestRequest request) {
-    BakeManifestRequest.TemplateRenderer templateRenderer = request.getTemplateRenderer();
-    if (templateRenderer == null) {
-      throw new IllegalArgumentException("The request type must be set (e.g. helm2).");
-    }
 
-    switch (templateRenderer) {
-      case HELM2:
-        return helmTemplateUtils;
-      default:
-        throw new IllegalArgumentException("Request type " + templateRenderer + " is not supported.");
-    }
+  @Override
+  public boolean handles(String type) {
+    return type.equals("helm");
   }
 
-  public Artifact bake(HelmBakeManifestRequest request) {
-    HelmTemplateUtils utils = templateUtils(request);
+  public Artifact bake(Map<String, Object> request) {
+    ObjectMapper mapper = new ObjectMapper();
+    HelmBakeManifestRequest bakeManifestRequest = mapper.convertValue(request, HelmBakeManifestRequest.class);
     BakeManifestEnvironment env = new BakeManifestEnvironment();
-    BakeRecipe recipe = utils.buildBakeRecipe(env, request);
+    BakeRecipe recipe = helmTemplateUtils.buildBakeRecipe(env, bakeManifestRequest);
 
     BakeStatus bakeStatus;
 
@@ -68,7 +63,7 @@ public class HelmBakeManifestService {
 
     return Artifact.builder()
         .type("embedded/base64")
-        .name(request.getOutputArtifactName())
+        .name(bakeManifestRequest.getOutputArtifactName())
         .reference(Base64.getEncoder().encodeToString(bakeStatus.getLogsContent().getBytes()))
         .build();
   }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.manifests.jinja;
+
+import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class JinjaBakeManifestRequest extends BakeManifestRequest {
+  public String inputFormat = "yaml";
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2019 Armory
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,24 @@
 
 package com.netflix.spinnaker.rosco.manifests.jinja;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.api.BakeStatus;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.jobs.JobExecutor;
 import com.netflix.spinnaker.rosco.jobs.JobRequest;
-import com.netflix.spinnaker.rosco.manifests.TemplateUtils;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.method.P;
 import org.springframework.stereotype.Component;
 import com.netflix.spinnaker.rosco.manifests.TemplateUtils.BakeManifestEnvironment;
 
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Map;
 import java.util.UUID;
 
 @Component
-public class JinjaBakeManifestService {
+public class JinjaBakeManifestService implements BakeManifestService {
 
   @Autowired
   JobExecutor jobExecutor;
@@ -40,7 +41,14 @@ public class JinjaBakeManifestService {
   @Autowired
   JinjaTemplateUtils templateUtils;
 
-  public Artifact bake(JinjaBakeManifestRequest bakeManifestRequest) {
+  @Override
+  public boolean handles(String type) {
+    return type.equals("jinja");
+  }
+
+  public Artifact bake(Map<String, Object> request) {
+    ObjectMapper mapper = new ObjectMapper();
+    JinjaBakeManifestRequest bakeManifestRequest = mapper.convertValue(request, JinjaBakeManifestRequest.class);
     BakeManifestEnvironment env = new BakeManifestEnvironment();
     BakeRecipe recipe = templateUtils.buildBakeRecipe(env, bakeManifestRequest);
 

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaBakeManifestService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.manifests.jinja;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.api.BakeStatus;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.jobs.JobExecutor;
+import com.netflix.spinnaker.rosco.jobs.JobRequest;
+import com.netflix.spinnaker.rosco.manifests.TemplateUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.method.P;
+import org.springframework.stereotype.Component;
+import com.netflix.spinnaker.rosco.manifests.TemplateUtils.BakeManifestEnvironment;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.UUID;
+
+@Component
+public class JinjaBakeManifestService {
+
+  @Autowired
+  JobExecutor jobExecutor;
+
+  @Autowired
+  JinjaTemplateUtils templateUtils;
+
+  public Artifact bake(JinjaBakeManifestRequest bakeManifestRequest) {
+    BakeManifestEnvironment env = new BakeManifestEnvironment();
+    BakeRecipe recipe = templateUtils.buildBakeRecipe(env, bakeManifestRequest);
+
+    BakeStatus bakeStatus;
+    try {
+      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString());
+      String jobId = jobExecutor.startJob(jobRequest);
+
+      bakeStatus = jobExecutor.updateJob(jobId);
+      while (bakeStatus == null || bakeStatus.getState() == BakeStatus.State.RUNNING) {
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException ignored){
+
+          }
+          bakeStatus = jobExecutor.updateJob(jobId);
+      }
+
+      if (bakeStatus.getResult() != BakeStatus.Result.SUCCESS) {
+        throw new IllegalStateException("Bake of " + bakeManifestRequest + "failed: " + bakeStatus.getLogsContent());
+      }
+    } finally {
+      env.cleanup();
+    }
+
+    return Artifact.builder()
+      .type("embedded/base64")
+      .name(bakeManifestRequest.getOutputName())
+      .reference(Base64.getEncoder().encodeToString(bakeStatus.getLogsContent().getBytes()))
+      .build();
+  }
+
+
+
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaTemplateUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.manifests.jinja;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.manifests.TemplateUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class JinjaTemplateUtils extends TemplateUtils {
+  public BakeRecipe buildBakeRecipe(BakeManifestEnvironment env, JinjaBakeManifestRequest request) {
+    BakeRecipe result = new BakeRecipe();
+    result.setName(request.getOutputName());
+
+    Path templatePath;
+    List<Path> valuePaths = new ArrayList<>();
+    List<Artifact> inputArtifacts = request.getInputArtifacts();
+
+    if (inputArtifacts == null || inputArtifacts.isEmpty()) {
+      throw new IllegalArgumentException("At least one input artifact must be provided to bake.");
+    }
+
+    try {
+      templatePath = downloadArtifactToTmpFile(env, inputArtifacts.get(0));
+
+      for (Artifact valueArtifact : inputArtifacts.subList(1, inputArtifacts.size())) {
+        valuePaths.add(downloadArtifactToTmpFile(env, valueArtifact));
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to fetch Jinja template: " + e.getMessage(), e);
+    }
+
+
+    List<String> command = new ArrayList<>();
+    command.add("jinja2");
+    command.add(templatePath.toString());
+    for (Path valuePath : valuePaths) {
+      command.add(valuePath.toString());
+    }
+
+    Map<String, Object> overrides = request.getOverrides();
+    if (overrides != null && !overrides.isEmpty()) {
+      List<String> overrideList = new ArrayList<>();
+      for (Map.Entry<String, Object> entry : overrides.entrySet()) {
+        command.add("-D");
+        command.add(entry.getKey() + "=" + entry.getValue().toString());
+      }
+    }
+
+    command.add("--format");
+    command.add(request.getInputFormat());
+
+    result.setCommand(command);
+    return result;
+  }
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/jinja/JinjaTemplateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2019 Armory
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/V2BakeryController.java
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/V2BakeryController.java
@@ -4,6 +4,8 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.manifests.BakeManifestRequest;
 import com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestRequest;
 import com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestService;
+import com.netflix.spinnaker.rosco.manifests.jinja.JinjaBakeManifestRequest;
+import com.netflix.spinnaker.rosco.manifests.jinja.JinjaBakeManifestService;
 import groovy.util.logging.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,14 +13,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @Slf4j
 public class V2BakeryController {
   @Autowired
   HelmBakeManifestService helmBakeManifestService;
 
+  @Autowired
+  JinjaBakeManifestService jinjaBakeManifestService;
+
+
   @RequestMapping(value = "/api/v2/manifest/bake/helm", method = RequestMethod.POST)
   Artifact doBake(@RequestBody HelmBakeManifestRequest bakeRequest) {
     return helmBakeManifestService.bake(bakeRequest);
+  }
+
+  @RequestMapping(value = "/api/v2/manifest/bake/jinja", method = RequestMethod.POST)
+  Artifact doJinjaBake(@RequestBody JinjaBakeManifestRequest bakeRequest) {
+    return jinjaBakeManifestService.bake(bakeRequest);
   }
 }


### PR DESCRIPTION
adds support for jinja as a manifest rendering engine. i would have
preferred to use `jinjava` for the rendering but job execution is really
coupled to a command line call so i opted for `jinja2-cli`.