### PR TITLE
fix(bake/manifests): capture only stdout in Helm bakery - 2nd attempt

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeStatus.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeStatus.groovy
@@ -50,6 +50,9 @@ class BakeStatus implements Serializable {
   String resource_id
 
   @JsonIgnore
+  String outputContent
+
+  @JsonIgnore
   String logsContent
 
   @JsonIgnore

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/JobRequest.groovy
@@ -28,6 +28,8 @@ class JobRequest {
   List<String> tokenizedCommand
   List<String> maskedParameters = []
   String jobId
+  /** Whether to merge command output and error streams. */
+  boolean combineStdOutAndErr = true
 
   List<String> getMaskedTokenizedCommand() {
     return tokenizedCommand.collect { String masked ->

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -64,7 +64,7 @@ class JobExecutorLocal implements JobExecutor {
           ByteArrayOutputStream stdErr
           if (jobRequest.combineStdOutAndErr) {
             stdOut = new ByteArrayOutputStream()
-            stdErr = stdOut
+            stdErr = null
             pumpStreamHandler = new PumpStreamHandler(stdOut)
           } else {
             stdOut = new ByteArrayOutputStream()
@@ -149,7 +149,7 @@ class JobExecutorLocal implements JobExecutor {
         }
 
         String outputContent = new String(stdOut.toByteArray())
-        String logsContent = stdOut.is(stdErr) ? outputContent : new String(stdErr.toByteArray())
+        String logsContent = (stdErr == null) ? outputContent : new String(stdErr.toByteArray())
 
         if (resultHandler.hasResult()) {
           log.info("State for $jobId changed with exit code $resultHandler.exitValue.")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -59,8 +59,18 @@ class JobExecutorLocal implements JobExecutor {
       new Action0() {
         @Override
         public void call() {
-          ByteArrayOutputStream stdOutAndErr = new ByteArrayOutputStream()
-          PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(stdOutAndErr)
+          PumpStreamHandler pumpStreamHandler
+          ByteArrayOutputStream stdOut
+          ByteArrayOutputStream stdErr
+          if (jobRequest.combineStdOutAndErr) {
+            stdOut = new ByteArrayOutputStream()
+            stdErr = stdOut
+            pumpStreamHandler = new PumpStreamHandler(stdOut)
+          } else {
+            stdOut = new ByteArrayOutputStream()
+            stdErr = new ByteArrayOutputStream()
+            pumpStreamHandler = new PumpStreamHandler(stdOut, stdErr)
+          }
           CommandLine commandLine
 
           if (jobRequest.tokenizedCommand) {
@@ -105,7 +115,8 @@ class JobExecutorLocal implements JobExecutor {
           jobIdToHandlerMap.put(jobId, [
             handler: resultHandler,
             watchdog: watchdog,
-            stdOutAndErr: stdOutAndErr
+            stdOut: stdOut,
+            stdErr: stdErr
           ])
         }
       }
@@ -128,14 +139,17 @@ class JobExecutorLocal implements JobExecutor {
         BakeStatus bakeStatus = new BakeStatus(id: jobId, resource_id: jobId)
 
         DefaultExecuteResultHandler resultHandler
-        ByteArrayOutputStream stdOutAndErr
+        ByteArrayOutputStream stdOut
+        ByteArrayOutputStream stdErr
 
         jobIdToHandlerMap[jobId].with {
           resultHandler = it.handler
-          stdOutAndErr = it.stdOutAndErr
+          stdOut = it.stdOut
+          stdErr = it.stdErr
         }
 
-        String logsContent = new String(stdOutAndErr.toByteArray())
+        String outputContent = new String(stdOut.toByteArray())
+        String logsContent = stdOut.is(stdErr) ? outputContent : new String(stdErr.toByteArray())
 
         if (resultHandler.hasResult()) {
           log.info("State for $jobId changed with exit code $resultHandler.exitValue.")
@@ -155,6 +169,10 @@ class JobExecutorLocal implements JobExecutor {
           jobIdToHandlerMap.remove(jobId)
         } else {
           bakeStatus.state = BakeStatus.State.RUNNING
+        }
+
+        if (outputContent) {
+          bakeStatus.outputContent = outputContent
         }
 
         if (logsContent) {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocalSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocalSpec.groovy
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.rosco.jobs.local
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.rosco.api.BakeStatus
+import com.netflix.spinnaker.rosco.jobs.JobRequest
+import com.netflix.spinnaker.rosco.jobs.JobExecutor
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class JobExecutorLocalSpec extends Specification implements TestDefaults {
+
+  private static final String BASH_SCRIPT = '''\
+    for i in {1..5}; do
+        echo "Output $i"
+        sleep 0.1
+        echo "Error $i" >&2
+        sleep 0.1
+    done
+    echo "Final output"
+  '''.stripIndent()
+  private static final String EXPECTED_OUTPUT = '''\
+    Output 1
+    Output 2
+    Output 3
+    Output 4
+    Output 5
+    Final output
+  '''.stripIndent()
+  private static final String EXPECTED_LOGS = '''\
+    Error 1
+    Error 2
+    Error 3
+    Error 4
+    Error 5
+  '''.stripIndent()
+  private static final String COMBINED_OUTPUT = '''\
+    Output 1
+    Error 1
+    Output 2
+    Error 2
+    Output 3
+    Error 3
+    Output 4
+    Error 4
+    Output 5
+    Error 5
+    Final output
+  '''.stripIndent()
+
+  @Unroll
+  void 'job executor runs command and captures stdout and stderr with combineStdOutAndErr set to #combineStdOutAndErr'() {
+    setup:
+      def jobRequest = new JobRequest(
+          tokenizedCommand: ["/bin/bash", "-c", BASH_SCRIPT],
+          jobId: SOME_JOB_ID,
+          combineStdOutAndErr: combineStdOutAndErr)
+
+      @Subject
+      def jobExecutorLocal = new JobExecutorLocal(
+          registry: new DefaultRegistry(),
+          timeoutMinutes: 1)
+
+    when:
+      def jobId = jobExecutorLocal.startJob(jobRequest)
+      // Give the script time to run + 100 ms fudge factor
+      sleep(1100)
+      def bakeStatus = jobExecutorLocal.updateJob(jobId)
+
+    then:
+      bakeStatus != null
+      bakeStatus.state == BakeStatus.State.COMPLETED
+      bakeStatus.result == BakeStatus.Result.SUCCESS
+      bakeStatus.outputContent == expectedOutput
+      bakeStatus.logsContent == expectedLogs
+
+    where:
+      combineStdOutAndErr | expectedOutput  | expectedLogs
+      true                | COMBINED_OUTPUT | COMBINED_OUTPUT
+      false               | EXPECTED_OUTPUT | EXPECTED_LOGS
+  }
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -45,7 +45,7 @@ public class HelmBakeManifestService {
     BakeStatus bakeStatus;
 
     try {
-      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString(), combineStdOutAndErr: false);
+      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString(), /* combineStdOutAndErr*/ false);
       String jobId = jobExecutor.startJob(jobRequest);
 
       bakeStatus = jobExecutor.updateJob(jobId);

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -45,7 +45,7 @@ public class HelmBakeManifestService {
     BakeStatus bakeStatus;
 
     try {
-      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString());
+      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString(), combineStdOutAndErr: false);
       String jobId = jobExecutor.startJob(jobRequest);
 
       bakeStatus = jobExecutor.updateJob(jobId);
@@ -69,7 +69,7 @@ public class HelmBakeManifestService {
     return Artifact.builder()
         .type("embedded/base64")
         .name(request.getOutputArtifactName())
-        .reference(Base64.getEncoder().encodeToString(bakeStatus.getLogsContent().getBytes()))
+        .reference(Base64.getEncoder().encodeToString(bakeStatus.getOutputContent().getBytes()))
         .build();
   }
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -45,7 +45,7 @@ public class HelmBakeManifestService {
     BakeStatus bakeStatus;
 
     try {
-      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString(), /* combineStdOutAndErr*/ false);
+      JobRequest jobRequest = new JobRequest(recipe.getCommand(), new ArrayList<>(), UUID.randomUUID().toString(), false);
       String jobId = jobExecutor.startJob(jobRequest);
 
       bakeStatus = jobExecutor.updateJob(jobId);


### PR DESCRIPTION
This is a fix for https://github.com/spinnaker/spinnaker/issues/3063.

Previously, #269 attempted to fix this issue by capturing stdout and stderr separately, however this change caused a regression and was reverted in #279.

This fix takes a similar approach to #269 but avoids the regression by keeping stdout and stderr completely separate and not attempting to merge the streams.  Additionally, the change is only enabled when baking Helm manifests, so other bake functionality will not be impacted.

One limitation of this change is that non-fatal warnings printed to stderr will be ignored if the `helm template` command exits with error code 0.  (Previously, non-fatal warnings would also not be reported, but would be merged into the output artifact data.  Consequently, the bake stage would appear to succeed but subsequent deploy stages would fail.)

A possible future enhancement would be to report non-fatal warnings to the end user and optionally fail the stage if anything is printed to stderr.