### PR TITLE
perf(redis): Stop using KEYS command in BakeStore

### DIFF
--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency('jacksonGuava')
   compile spinnaker.dependency('jedis')
+  compile spinnaker.dependency('korkJedis')
   compile spinnaker.dependency('korkWeb')
   compile spinnaker.dependency('korkArtifacts')
   compileOnly spinnaker.dependency("lombok")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.rosco.config
 
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.rosco.executor.BakePoller
 import com.netflix.spinnaker.rosco.persistence.BakeStore
 import com.netflix.spinnaker.rosco.persistence.RedisBackedBakeStore
@@ -58,8 +60,13 @@ class RoscoConfiguration {
   }
 
   @Bean
-  BakeStore bakeStore(JedisPool jedisPool) {
-    new RedisBackedBakeStore(jedisPool)
+  BakeStore bakeStore(JedisPool jedisPool, RedisClientDelegate redisClientDelegate) {
+    new RedisBackedBakeStore(jedisPool, redisClientDelegate)
+  }
+
+  @Bean
+  RedisClientDelegate redisClientDelegate(JedisPool jedisPool) {
+    return new JedisClientDelegate(jedisPool)
   }
 
   @Bean


### PR DESCRIPTION
Replace `jedis.keys` invocations with a kork `withKeyScan` invocation, like https://github.com/spinnaker/igor/pull/270 (instead of implementing a scan loop directly). Came up from Redis slowlog entries reaching dozens of ms. 

Note that I did not change out the other `jedisPool` usages in `RedisBackedBakeStore.groovy`. Replacing them introduced a bunch of these 'ambiguous call' warns:
![Screen Shot 2019-04-22 at 9 56 18 AM](https://user-images.githubusercontent.com/40628/56512664-e6434480-64e4-11e9-8654-ab8c2f156139.png)

I was also unable to locate a `jedis.time()` signature for `getTimeInMilliseconds()`. The 'TIME' command is seemingly only exposed directly on BinaryClient.

For these reasons I only touched the 'keys' invocations in this initial commit.