### PR TITLE
fix(artifacts): Fix NPE on empty artifact

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
@@ -46,9 +46,11 @@ public abstract class TemplateUtils {
 
     Response response = retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
 
-    InputStream inputStream = response.getBody().in();
-    IOUtils.copy(inputStream, outputStream);
-    inputStream.close();
+    if (response.getBody() != null) {
+      InputStream inputStream = response.getBody().in();
+      IOUtils.copy(inputStream, outputStream);
+      inputStream.close();
+    }
     outputStream.close();
 
     return path;


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4387

If an artifact is empty, we throw an NPE when downloading it rather than just pass an empty artifact along to the caller.

In general it's not overly useful to have an empty artifact, but in some cases (ex: a values.yaml file for a Helm bake) it's reasonable to have no content.