### PR TITLE
fix(bake): Improve error message

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/TemplateUtils.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.rosco.manifests;
 import com.amazonaws.util.IOUtils;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.services.ClouddriverService;
 import lombok.Getter;
@@ -41,6 +42,9 @@ public abstract class TemplateUtils {
   }
 
   protected Path downloadArtifactToTmpFile(BakeManifestEnvironment env, Artifact artifact) throws IOException {
+    if (artifact.getReference() == null) {
+      throw new InvalidRequestException("Input artifact has an empty 'reference' field.");
+    }
     Path path = Paths.get(env.getStagingPath().toString(), nameFromReference(artifact.getReference()));
     OutputStream outputStream = new FileOutputStream(path.toString());
 


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4110

When supplying an artifact without a reference, we currently throw an NPE that is hard to debug. Replace this with a better error message.

(At some point we could consider if we even need a reference at all, or if we could fall back to something else, but for now this will at least make the restriction clearer.)