### PR TITLE
test(core): Fix tests that break with groovy upgrade

### DIFF
--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/controllers/BakeryController.groovy
@@ -188,7 +188,7 @@ class BakeryController {
 
       def bakeRecipe = cloudProviderBakeHandler.produceBakeRecipe(region, bakeRequest)
       def jobRequest = new JobRequest(tokenizedCommand: bakeRecipe.command,
-                                      maskedParameters: cloudProviderBakeHandler.maskedPackerParameters,
+                                      maskedParameters: cloudProviderBakeHandler.getMaskedPackerParameters(),
                                       jobId: bakeRequest.request_id,
                                       executionId: bakeRequest.spinnaker_execution_id)
 

--- a/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
+++ b/rosco-web/src/test/groovy/com/netflix/spinnaker/rosco/controllers/BakeryControllerSpec.groovy
@@ -49,7 +49,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
@@ -87,7 +89,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
@@ -130,7 +134,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
@@ -166,7 +172,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
@@ -209,7 +217,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
@@ -268,7 +278,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
@@ -301,7 +313,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
                                         package_name: PACKAGE_NAME,
@@ -335,7 +349,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
@@ -379,7 +395,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
@@ -420,7 +438,9 @@ class BakeryControllerSpec extends Specification {
     setup:
       def registry = new DefaultRegistry()
       def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry)
-      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler)
+      def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+        getMaskedPackerParameters() >> []
+      }
       def bakeStoreMock = Mock(RedisBackedBakeStore)
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(user: "someuser@gmail.com",


### PR DESCRIPTION
A few of the rosco tests fail when we upgrade groovy because groovy no longer considers objects equal they are identical except that a field is null in one vs empty array in the other.

That was masking the fact that we weren't stubbing out the getMaskedPackerParameters function on our mock CloudProviderBakeHandler. Add in that stubbing, and also change the calling code to use the actual accessor rather than the groovy-generated synthetic one.

There's probably a way to factor out some of the common logic in the tests so changes like this don't need to touch as many lines, but for now just making the required change in each test.