### PR TITLE
feat(provider/alicloud): Add Alibaba Cloud bakery to build VM image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rosco
 
 A bakery for use by Spinnaker to produce machine images.
 
-It presently supports producing Google Compute Engine images, AWS amis and Azure images. It relies on packer and can be easily extended to support additional platforms.
+It presently supports producing Alibaba Cloud images, Google Compute Engine images, AWS amis and Azure images. It relies on packer and can be easily extended to support additional platforms.
 
 It exposes a REST api which can be experimented with via the Swagger UI: http://localhost:8087/swagger-ui.html
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -85,7 +85,7 @@ class BakeRequest {
   String spinnaker_execution_id
 
   static enum CloudProviderType {
-    aws, azure, docker, gce, oracle
+    alicloud, aws, azure, docker, gce, oracle
   }
 
   static enum Label {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandler.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandler.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 Alibaba Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.alicloud;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.netflix.spinnaker.rosco.api.Bake;
+import com.netflix.spinnaker.rosco.api.BakeOptions;
+import com.netflix.spinnaker.rosco.api.BakeOptions.BaseImage;
+import com.netflix.spinnaker.rosco.api.BakeRequest;
+import com.netflix.spinnaker.rosco.providers.CloudProviderBakeHandler;
+import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration.AliCloudBakeryDefaults;
+import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration.AliCloudOperatingSystemVirtualizationSettings;
+import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration.AliCloudVirtualizationSettings;
+import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AliCloudBakeHandler extends CloudProviderBakeHandler {
+
+  private static final String IMAGE_NAME_TOKEN = "alicloud-ecs: Creating image:";
+
+  ImageNameFactory imageNameFactory = new ImageNameFactory();
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Autowired AliCloudBakeryDefaults alicloudBakeryDefaults;
+
+  @Override
+  public Object getBakeryDefaults() {
+    return alicloudBakeryDefaults;
+  }
+
+  @Override
+  public BakeOptions getBakeOptions() {
+    List<AliCloudOperatingSystemVirtualizationSettings> settings =
+        alicloudBakeryDefaults.getBaseImages();
+    List<BaseImage> baseImages = new ArrayList<>();
+    for (AliCloudOperatingSystemVirtualizationSettings baseImage : settings) {
+      baseImages.add(baseImage.getBaseImage());
+    }
+
+    BakeOptions bakeOptions = new BakeOptions();
+    bakeOptions.setCloudProvider(BakeRequest.CloudProviderType.alicloud.toString());
+    bakeOptions.setBaseImages(baseImages);
+    return bakeOptions;
+  }
+
+  @Override
+  public Object findVirtualizationSettings(String region, BakeRequest bakeRequest) {
+    List<AliCloudOperatingSystemVirtualizationSettings> settings =
+        alicloudBakeryDefaults.getBaseImages();
+    List<AliCloudOperatingSystemVirtualizationSettings> virtualizationSettings = new ArrayList<>();
+    for (AliCloudOperatingSystemVirtualizationSettings setting : settings) {
+      if (setting.getBaseImage().getId().equals(bakeRequest.getBase_os())) {
+        virtualizationSettings.add(setting);
+      }
+    }
+
+    if (virtualizationSettings.size() == 0) {
+      throw new IllegalArgumentException(
+          "No virtualization settings found for '" + bakeRequest.getBase_os() + "'.");
+    }
+
+    AliCloudVirtualizationSettings alicloudVirtualizationSettings = null;
+
+    for (AliCloudOperatingSystemVirtualizationSettings virtualizationSetting :
+        virtualizationSettings) {
+      for (AliCloudVirtualizationSettings setting :
+          virtualizationSetting.getVirtualizationSettings()) {
+        if (region.equals(setting.getRegion())) {
+          alicloudVirtualizationSettings = setting;
+          break;
+        }
+      }
+    }
+
+    if (alicloudVirtualizationSettings == null) {
+      throw new IllegalArgumentException(
+          "No virtualization settings found for region '"
+              + region
+              + "', operating system '"
+              + bakeRequest.getBase_os()
+              + "'.");
+    }
+
+    if (StringUtils.isNotEmpty(bakeRequest.getBase_ami())) {
+      try {
+        alicloudVirtualizationSettings =
+            (AliCloudVirtualizationSettings) alicloudVirtualizationSettings.clone();
+      } catch (CloneNotSupportedException e) {
+        e.printStackTrace();
+      }
+
+      alicloudVirtualizationSettings.setSourceImage(bakeRequest.getBase_ami());
+    }
+
+    return alicloudVirtualizationSettings;
+  }
+
+  @Override
+  public String getTemplateFileName(BaseImage baseImage) {
+    String f1 = baseImage.getTemplateFile();
+    String f2 = alicloudBakeryDefaults.getTemplateFile();
+    return StringUtils.isNotEmpty(f1) ? f1 : f2;
+  }
+
+  @Override
+  public Map buildParameterMap(
+      String region,
+      Object virtualizationSettings,
+      String imageName,
+      BakeRequest bakeRequest,
+      String appVersionStr) {
+    Map<String, Object> parameterMap = new HashMap<>(20);
+    AliCloudVirtualizationSettings aliCloudVirtualizationSettings =
+        objectMapper.convertValue(virtualizationSettings, AliCloudVirtualizationSettings.class);
+    parameterMap.put("alicloud_region", region);
+    parameterMap.put("alicloud_instance_type", aliCloudVirtualizationSettings.getInstanceType());
+    parameterMap.put("alicloud_source_image", aliCloudVirtualizationSettings.getSourceImage());
+    parameterMap.put("alicloud_target_image", imageName);
+
+    if (StringUtils.isNotEmpty(aliCloudVirtualizationSettings.getSshUserName())) {
+      parameterMap.put("alicloud_ssh_username", aliCloudVirtualizationSettings.getSshUserName());
+    }
+
+    if (StringUtils.isNotEmpty(alicloudBakeryDefaults.getAlicloudAccessKey())
+        && StringUtils.isNotEmpty(alicloudBakeryDefaults.getAlicloudSecretKey())) {
+      parameterMap.put("alicloud_access_key", alicloudBakeryDefaults.getAlicloudAccessKey());
+      parameterMap.put("alicloud_secret_key", alicloudBakeryDefaults.getAlicloudSecretKey());
+    }
+
+    if (StringUtils.isNotEmpty(alicloudBakeryDefaults.getAlicloudVSwitchId())) {
+      parameterMap.put("alicloud_vswitch_id", alicloudBakeryDefaults.getAlicloudVSwitchId());
+    }
+
+    if (StringUtils.isNotEmpty(alicloudBakeryDefaults.getAlicloudVpcId())) {
+      parameterMap.put("alicloud_vpc_id", alicloudBakeryDefaults.getAlicloudVpcId());
+    }
+
+    if (StringUtils.isNotEmpty(bakeRequest.getBuild_info_url())) {
+      parameterMap.put("build_info_url", bakeRequest.getBuild_info_url());
+    }
+
+    if (StringUtils.isNotEmpty(appVersionStr)) {
+      parameterMap.put("appversion", appVersionStr);
+    }
+
+    return parameterMap;
+  }
+
+  @Override
+  public Bake scrapeCompletedBakeResults(String region, String bakeId, String logsContent) {
+    String amiId = "";
+    String imageName = "";
+
+    // Resolve this by storing bake details in redis and querying oort for
+    // amiId from amiName.
+    String[] lines = logsContent.split("\\n");
+    for (String line : lines) {
+      if (line.indexOf(IMAGE_NAME_TOKEN) != -1) {
+        String[] s = line.split(" ");
+        imageName = s[s.length - 1];
+      } else if (line.indexOf(region) != -1) {
+        String[] s = line.split(" ");
+        amiId = s[s.length - 1];
+      }
+    }
+    Bake bake = new Bake();
+    bake.setId(bakeId);
+    bake.setAmi(amiId);
+    bake.setImage_name(imageName);
+
+    return bake;
+  }
+
+  @Override
+  public String produceProviderSpecificBakeKeyComponent(String region, BakeRequest bakeRequest) {
+    return region;
+  }
+
+  @Override
+  public ImageNameFactory getImageNameFactory() {
+    return imageNameFactory;
+  }
+}

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/alicloud/config/RoscoAliCloudConfiguration.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/alicloud/config/RoscoAliCloudConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Alibaba Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.alicloud.config;
+
+import com.netflix.spinnaker.rosco.api.BakeOptions;
+import com.netflix.spinnaker.rosco.api.BakeRequest;
+import com.netflix.spinnaker.rosco.providers.alicloud.AliCloudBakeHandler;
+import com.netflix.spinnaker.rosco.providers.registry.CloudProviderBakeHandlerRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("alicloud.enabled")
+@ComponentScan("com.netflix.spinnaker.rosco.providers.alicloud")
+public class RoscoAliCloudConfiguration {
+
+  private final CloudProviderBakeHandlerRegistry cloudProviderBakeHandlerRegistry;
+
+  private final AliCloudBakeHandler alicloudBakeHandler;
+
+  @Autowired
+  public RoscoAliCloudConfiguration(
+      CloudProviderBakeHandlerRegistry cloudProviderBakeHandlerRegistry,
+      AliCloudBakeHandler alicloudBakeHandler) {
+    this.cloudProviderBakeHandlerRegistry = cloudProviderBakeHandlerRegistry;
+    this.alicloudBakeHandler = alicloudBakeHandler;
+  }
+
+  @Bean
+  @ConfigurationProperties("alicloud.bakery-defaults")
+  AliCloudBakeryDefaults alicloudBakeryDefaults() {
+    return new AliCloudBakeryDefaults();
+  }
+
+  @Data
+  public static class AliCloudBakeryDefaults {
+    private String alicloudAccessKey;
+    private String alicloudSecretKey;
+    private String alicloudVSwitchId;
+    private String alicloudVpcId;
+    private String templateFile;
+    private List<AliCloudOperatingSystemVirtualizationSettings> baseImages = new ArrayList<>();
+  }
+
+  @Data
+  public static class AliCloudOperatingSystemVirtualizationSettings {
+    private BakeOptions.BaseImage baseImage;
+    private List<AliCloudVirtualizationSettings> virtualizationSettings = new ArrayList<>();
+  }
+
+  @Data
+  public static class AliCloudVirtualizationSettings implements Cloneable {
+    private String region;
+    private String instanceType;
+    private String sourceImage;
+    private String sshUserName;
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+      return super.clone();
+    }
+  }
+
+  @PostConstruct
+  void init() {
+    cloudProviderBakeHandlerRegistry.register(
+        BakeRequest.CloudProviderType.alicloud, alicloudBakeHandler);
+  }
+}

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
@@ -1,0 +1,528 @@
+/*
+ * Copyright 2019 Alibaba Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.alicloud
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.rosco.api.Bake
+import com.netflix.spinnaker.rosco.api.BakeRequest
+import com.netflix.spinnaker.rosco.config.RoscoConfiguration
+import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration
+import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory
+import com.netflix.spinnaker.rosco.providers.util.PackerCommandFactory
+import com.netflix.spinnaker.rosco.providers.util.TestDefaults
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
+
+  private static final String REGION = "cn-hangzhou"
+  private static final String SOURCE_UBUNTU_IMAGE_NAME = "ubuntu_16_04_64.vhd"
+    private static final String SOURCE_TRUSTY_IMAGE_NAME = "trusty_16_04_64.vhd"
+
+  @Shared
+  String configDir = "/some/path"
+
+  @Shared
+  RoscoAliCloudConfiguration.AliCloudBakeryDefaults alicloudBakeryDefaults
+
+  void setupSpec() {
+    def alicloudBakeryDefaultsJson = [
+      templateFile: "alicloud_template.json",
+      baseImages: [
+        [
+          baseImage: [
+            id: "ubuntu",
+            packageType: "DEB",
+          ],
+          virtualizationSettings: [
+            [
+              region: REGION,
+              instanceType: "ecs.c5.large",
+              sourceImage: SOURCE_UBUNTU_IMAGE_NAME,
+              sshUserName: "root"
+            ],
+            [
+              region: REGION,
+              instanceType: "ecs.g5.large",
+              sourceImage: SOURCE_UBUNTU_IMAGE_NAME,
+              sshUserName: "root"
+            ]
+          ]
+        ],
+        [
+          baseImage: [
+            id: "trusty",
+            packageType: "DEB",
+          ],
+          virtualizationSettings: [
+            [
+              region: REGION,
+              instanceType: "ecs.c5.large",
+              sourceImage: SOURCE_TRUSTY_IMAGE_NAME,
+              sshUserName: "root"
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    alicloudBakeryDefaults = new ObjectMapper().convertValue(alicloudBakeryDefaultsJson, RoscoAliCloudConfiguration.AliCloudBakeryDefaults)
+  }
+
+  void 'can scrape packer logs for image name'() {
+    setup:
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults)
+
+    when:
+      def logsContent =
+        "    alicloud-ecs: Reading package lists...\n" +
+        "==> alicloud-ecs: Deleting image snapshots.\n" +
+        "==> alicloud-ecs: Creating image: all-timestamp-ubuntu-1604\n" +
+        "alicloud-ecs: Detach keypair packer_5d204762-9187cb8 from instance: i-12345abced\n" +
+        "==> alicloud-ecs: Cleaning up 'EIP'\n" +
+        "==> alicloud-ecs: Cleaning up 'instance'\n" +
+        "==> alicloud-ecs: Cleaning up 'security group'\n" +
+        "==> alicloud-ecs: Cleaning up 'vSwitch'\n" +
+        "==> alicloud-ecs: Cleaning up 'VPC'\n" +
+        "==> alicloud-ecs: Deleting temporary keypair...\n" +
+        "Build 'alicloud-ecs' finished.\n" +
+        "\n" +
+        "==> Builds finished. The artifacts of successful builds are:\n" +
+        "--> alicloud-ecs: Alicloud images were created:\n" +
+        "\n" +
+        "cn-hangzhou: m-12345abced"
+
+      Bake bake = aliCloudBakeHandler.scrapeCompletedBakeResults(REGION, "123", logsContent)
+
+
+    then:
+      with (bake) {
+        id == "123"
+        ami == "m-12345abced"
+        image_name == "all-timestamp-ubuntu-1604"
+      }
+  }
+
+  void 'scraping returns null for missing image id'() {
+    setup:
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults)
+
+    when:
+      def logsContent =
+        "    alicloud-ecs: Reading package lists...\n" +
+        "==> alicloud-ecs: Deleting image snapshots.\n" +
+        "==> alicloud-ecs: Creating image: all-timestamp-ubuntu-1604\n" +
+        "alicloud-ecs: Detach keypair packer_5d204762-9187cb8 from instance: i-12345abced\n" +
+        "==> alicloud-ecs: Cleaning up 'EIP'\n" +
+        "==> alicloud-ecs: Cleaning up 'instance'\n" +
+        "==> alicloud-ecs: Cleaning up 'security group'\n" +
+        "==> alicloud-ecs: Cleaning up 'vSwitch'\n" +
+        "==> alicloud-ecs: Cleaning up 'VPC'\n" +
+        "==> alicloud-ecs: Deleting temporary keypair...\n" +
+        "Build 'alicloud-ecs' finished.\n" +
+        "\n" +
+        "==> Builds finished. The artifacts of successful builds are:\n" +
+        "--> alicloud-ecs: Alicloud images were created:\n"
+
+      Bake bake = aliCloudBakeHandler.scrapeCompletedBakeResults(REGION, "123", logsContent)
+
+    then:
+      with (bake) {
+        id == "123"
+        !ami
+        image_name == "all-timestamp-ubuntu-1604"
+      }
+  }
+
+  void 'scraping returns null for missing image name'() {
+    setup:
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults)
+
+    when:
+      def logsContent =
+        "    alicloud-ecs: Reading package lists...\n" +
+        "==> alicloud-ecs: Deleting image snapshots.\n"
+
+    Bake bake = aliCloudBakeHandler.scrapeCompletedBakeResults(REGION, "123", logsContent)
+
+    then:
+      with (bake) {
+        id == "123"
+        !ami
+        !image_name
+      }
+  }
+
+  void 'produces packer command with all required parameters for ubuntu'() {
+    setup:
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "ubuntu",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud)
+      def targetImageName = "kato-timestamp-ubuntu"
+      def osPackages = parseDebOsPackageNames(PACKAGES_NAME)
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        alicloud_target_image: targetImageName,
+        repository: DEBIAN_REPOSITORY,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        packages: PACKAGES_NAME,
+        configDir: configDir
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+    aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+  }
+
+
+  void 'produces packer command with all required parameters for ubuntu, and overriding base ami'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "ubuntu",
+                                        base_ami: "ubuntu_14_04_64.vhd",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud)
+      def targetImageName = "kato-timestamp-ubuntu"
+      def osPackages = parseDebOsPackageNames(PACKAGES_NAME)
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: "ubuntu_14_04_64.vhd",
+        alicloud_target_image: targetImageName,
+        repository: DEBIAN_REPOSITORY,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        packages: PACKAGES_NAME,
+        configDir: configDir
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+    aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+  }
+
+  void 'produces packer command with all required parameters for ubuntu, and overriding template filename'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "ubuntu",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                        template_file_name: "somePackerTemplate.json")
+      def osPackages = parseDebOsPackageNames(PACKAGES_NAME)
+      def targetImageName = "kato-timestamp-ubuntu"
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        alicloud_target_image: targetImageName,
+        repository: DEBIAN_REPOSITORY,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        packages: PACKAGES_NAME,
+        configDir: configDir
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+  }
+
+  void 'produces packer command with all required parameters for ubuntu, and adding extended attributes'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "ubuntu",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                        extended_attributes: [someAttr1: "someValue1", someAttr2: "someValue2"])
+      def targetImageName = "kato-timestamp-ubuntu"
+      def osPackages = parseDebOsPackageNames(PACKAGES_NAME)
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: SOURCE_UBUNTU_IMAGE_NAME,
+        alicloud_target_image: targetImageName,
+        repository: DEBIAN_REPOSITORY,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        packages: PACKAGES_NAME,
+        configDir: configDir,
+        someAttr1: "someValue1",
+        someAttr2: "someValue2"
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+  }
+
+  void 'throws exception when virtualization settings are not found for specified operating system'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "centos",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud)
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      IllegalArgumentException e = thrown()
+      e.message == "No virtualization settings found for 'centos'."
+  }
+
+  void 'throws exception when virtualization settings are not found for specified region, operating system'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "trusty",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud)
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe("cn-beijing", bakeRequest)
+
+    then:
+      IllegalArgumentException e = thrown()
+      e.message == "No virtualization settings found for region 'cn-beijing', operating system 'trusty'."
+  }
+
+  void 'produce a default Alibaba Cloud bakeKey with image name'() {
+    setup:
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: PACKAGES_NAME,
+                                        base_os: "centos",
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                        ami_name: "kato-app")
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults)
+
+    when:
+      String bakeKey = aliCloudBakeHandler.produceBakeKey(REGION, bakeRequest)
+
+    then:
+      bakeKey == "bake:alicloud:centos:kato-app:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:cn-hangzhou"
+  }
+
+  void 'do not consider ami suffix when composing bake key'() {
+    setup:
+      def bakeRequest1 = new BakeRequest(user: "someuser@gmail.com",
+                                         package_name: PACKAGES_NAME,
+                                         base_os: "centos",
+                                         cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                         ami_suffix: "1.0")
+      def bakeRequest2 = new BakeRequest(user: "someuser@gmail.com",
+                                         package_name: PACKAGES_NAME,
+                                         base_os: "centos",
+                                         cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                         ami_suffix: "2.0")
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(alicloudBakeryDefaults: alicloudBakeryDefaults)
+
+    when:
+      String bakeKey1 = aliCloudBakeHandler.produceBakeKey(REGION, bakeRequest1)
+      String bakeKey2 = aliCloudBakeHandler.produceBakeKey(REGION, bakeRequest2)
+
+    then:
+      bakeKey1 == "bake:alicloud:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:cn-hangzhou"
+      bakeKey2 == bakeKey1
+  }
+
+  void 'produces packer command with all required parameters including shared_with multiple accounts as extended_attribute'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def fullyQualifiedPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      def buildHost = "http://some-build-server:8080"
+      def buildInfoUrl = "http://some-build-server:8080/repogroup/repo/builds/320282"
+      def share_account = "000001, 000002"
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: fullyQualifiedPackageName,
+                                        base_os: "trusty",
+                                        build_host: buildHost,
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                        extended_attributes: [share_with: share_account],
+                                        build_info_url: buildInfoUrl)
+      def osPackages = parseDebOsPackageNames(fullyQualifiedPackageName)
+      def targetImageName = "kato-timestamp-trusty"
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: SOURCE_TRUSTY_IMAGE_NAME,
+        alicloud_target_image: targetImageName,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        repository: DEBIAN_REPOSITORY,
+        packages: fullyQualifiedPackageName,
+        share_with_1: "000001",
+        share_with_2: "000002",
+        configDir: configDir,
+        appversion: appVersionStr,
+        build_host: buildHost,
+        build_info_url: buildInfoUrl
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY,
+                                                         yumRepository: YUM_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+  }
+
+  void 'produces packer command with all required parameters including copy_to multiple regions as extended_attribute'() {
+    setup:
+      def imageNameFactoryMock = Mock(ImageNameFactory)
+      def packerCommandFactoryMock = Mock(PackerCommandFactory)
+      def fullyQualifiedPackageName = "nflx-djangobase-enhanced_0.1-h12.170cdbd_all"
+      def appVersionStr = "nflx-djangobase-enhanced-0.1-170cdbd.h12"
+      def buildHost = "http://some-build-server:8080"
+      def buildInfoUrl = "http://some-build-server:8080/repogroup/repo/builds/320282"
+      def copy_regions = "cn-beijing, cn-shanghai"
+      def bakeRequest = new BakeRequest(user: "someuser@gmail.com",
+                                        package_name: fullyQualifiedPackageName,
+                                        base_os: "trusty",
+                                        build_host: buildHost,
+                                        cloud_provider_type: BakeRequest.CloudProviderType.alicloud,
+                                        extended_attributes: [copy_to: copy_regions],
+                                        build_info_url: buildInfoUrl)
+      def osPackages = parseDebOsPackageNames(fullyQualifiedPackageName)
+      def targetImageName = "kato-timestamp-trusty"
+      def parameterMap = [
+        alicloud_region: REGION,
+        alicloud_ssh_username: "root",
+        alicloud_instance_type: "ecs.c5.large",
+        alicloud_source_image: SOURCE_TRUSTY_IMAGE_NAME,
+        alicloud_target_image: targetImageName,
+        package_type: DEB_PACKAGE_TYPE.util.packageType,
+        repository: DEBIAN_REPOSITORY,
+        packages: fullyQualifiedPackageName,
+        copy_to_1: "cn-beijing",
+        copy_to_2: "cn-shanghai",
+        configDir: configDir,
+        appversion: appVersionStr,
+        build_host: buildHost,
+        build_info_url: buildInfoUrl
+      ]
+
+      @Subject
+      AliCloudBakeHandler aliCloudBakeHandler = new AliCloudBakeHandler(configDir: configDir,
+                                                         alicloudBakeryDefaults: alicloudBakeryDefaults,
+                                                         imageNameFactory: imageNameFactoryMock,
+                                                         packerCommandFactory: packerCommandFactoryMock,
+                                                         debianRepository: DEBIAN_REPOSITORY,
+                                                         yumRepository: YUM_REPOSITORY)
+
+    when:
+      aliCloudBakeHandler.produceBakeRecipe(REGION, bakeRequest)
+
+    then:
+      1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
+      1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
+      1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
+      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+  }
+}

--- a/rosco-web/config/packer/alicloud-multi.json
+++ b/rosco-web/config/packer/alicloud-multi.json
@@ -1,0 +1,83 @@
+{
+  "variables": {
+    "alicloud_access_key": "",
+    "alicloud_secret_key": "",
+    "alicloud_vswitch_id": "{{env `ALICLOUD_VSWITCH_ID`}}",
+    "alicloud_vpc_id": "{{env `ALICLOUD_VPC_ID`}}",
+    "alicloud_region": null,
+    "alicloud_ssh_username": null,
+    "alicloud_instance_type": null,
+    "alicloud_source_image": null,
+    "alicloud_target_image": null,
+    "alicloud_internet_charge_type": "PayByTraffic",
+    "alicloud_internet_max_bandwidth_out": "10",
+    "appversion": "",
+    "build_host": "",
+    "repository": "",
+    "package_type": "",
+    "packages": "",
+    "upgrade": "",
+    "configDir": null,
+    "share_with_1": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_2": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_3": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_4": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_5": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_6": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_7": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_8": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_9": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "share_with_10": "{{env `SPINNAKER_ALICLOUD_DEFAULT_ACCOUNT`}}",
+    "copy_to_1": "{{env `SPINNAKER_ALICLOUD_DEFAULT_REGION`}}",
+    "copy_to_2": "{{env `SPINNAKER_ALICLOUD_DEFAULT_REGION`}}",
+    "copy_to_3": "{{env `SPINNAKER_ALICLOUD_DEFAULT_REGION`}}",
+    "copy_to_4": "{{env `SPINNAKER_ALICLOUD_DEFAULT_REGION`}}",
+    "copy_to_5": "{{env `SPINNAKER_ALICLOUD_DEFAULT_REGION`}}"
+  },
+  "builders": [{
+    "type":"alicloud-ecs",
+    "access_key": "{{user `alicloud_access_key`}}",
+    "secret_key": "{{user `alicloud_secret_key`}}",
+    "region": "{{user `alicloud_region`}}",
+    "source_image": "{{user `alicloud_source_image`}}",
+    "image_name": "{{user `alicloud_target_image`}}",
+    "vswitch_id": "{{user `alicloud_vswitch_id`}}",
+    "vpc_id": "{{user `alicloud_vpc_id`}}",
+    "ssh_username": "{{user `alicloud_ssh_username`}}",
+    "instance_type": "{{user `alicloud_instance_type`}}",
+    "internet_charge_type": "{{user `alicloud_internet_charge_type`}}",
+    "internet_max_bandwidth_out": "{{user `alicloud_internet_max_bandwidth_out`}}",
+    "io_optimized": "true",
+    "instance_name": "spinnaker-build-{{user `alicloud_target_image`}}",
+    "image_share_account": [
+      "{{user `share_with_1`}}",
+      "{{user `share_with_2`}}",
+      "{{user `share_with_3`}}",
+      "{{user `share_with_4`}}",
+      "{{user `share_with_5`}}",
+      "{{user `share_with_6`}}",
+      "{{user `share_with_7`}}",
+      "{{user `share_with_8`}}",
+      "{{user `share_with_9`}}",
+      "{{user `share_with_10`}}"
+    ],
+    "image_copy_regions": [
+      "{{user `copy_to_1`}}",
+      "{{user `copy_to_2`}}",
+      "{{user `copy_to_3`}}",
+      "{{user `copy_to_4`}}",
+      "{{user `copy_to_5`}}"
+    ]
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "{{user `configDir`}}/install_packages.sh",
+    "environment_vars": [
+      "repository={{user `repository`}}",
+      "package_type={{user `package_type`}}",
+      "packages={{user `packages`}}",
+      "upgrade={{user `upgrade`}}"
+    ],
+    "pause_before": "30s"
+  }]
+}

--- a/rosco-web/config/packer/alicloud.json
+++ b/rosco-web/config/packer/alicloud.json
@@ -1,0 +1,49 @@
+{
+  "variables": {
+    "alicloud_access_key": "",
+    "alicloud_secret_key": "",
+    "alicloud_vswitch_id": "{{env `ALICLOUD_VSWITCH_ID`}}",
+    "alicloud_vpc_id": "{{env `ALICLOUD_VPC_ID`}}",
+    "alicloud_region": null,
+    "alicloud_ssh_username": null,
+    "alicloud_instance_type": null,
+    "alicloud_source_image": null,
+    "alicloud_target_image": null,
+    "alicloud_internet_charge_type": "PayByTraffic",
+    "alicloud_internet_max_bandwidth_out": "10",
+    "appversion": "",
+    "build_host": "",
+    "repository": "",
+    "package_type": "",
+    "packages": "",
+    "upgrade": "",
+    "configDir": null
+  },
+  "builders": [{
+    "type":"alicloud-ecs",
+    "access_key": "{{user `alicloud_access_key`}}",
+    "secret_key": "{{user `alicloud_secret_key`}}",
+    "region": "{{user `alicloud_region`}}",
+    "source_image": "{{user `alicloud_source_image`}}",
+    "image_name": "{{user `alicloud_target_image`}}",
+    "vswitch_id": "{{user `alicloud_vswitch_id`}}",
+    "vpc_id": "{{user `alicloud_vpc_id`}}",
+    "ssh_username": "{{user `alicloud_ssh_username`}}",
+    "instance_type": "{{user `alicloud_instance_type`}}",
+    "internet_charge_type": "{{user `alicloud_internet_charge_type`}}",
+    "internet_max_bandwidth_out": "{{user `alicloud_internet_max_bandwidth_out`}}",
+    "io_optimized": "true",
+    "instance_name": "spinnaker-build-{{user `alicloud_target_image`}}"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "{{user `configDir`}}/install_packages.sh",
+    "environment_vars": [
+      "repository={{user `repository`}}",
+      "package_type={{user `package_type`}}",
+      "packages={{user `packages`}}",
+      "upgrade={{user `upgrade`}}"
+    ],
+    "pause_before": "30s"
+  }]
+}

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -46,6 +46,55 @@ defaultCloudProviderType: aws
 
 templatesNeedingRoot: aws-chroot.json
 
+alicloud:
+  # The property referenced below, ALICLOUD_ENABLED, is not set in the
+  # 'unified config' supported by the spinnaker/spinnaker project. If you
+  # copy/paste this section into a new rosco-local.yml file for use with a
+  # pre-built Spinnaker image, make sure to either replace ALICLOUD_ENABLED
+  # with SPINNAKER_ALICLOUD_ENABLED or to explicitly set the property's value
+  # to true.
+  enabled: ${ALICLOUD_ENABLED:false}
+  bakeryDefaults:
+    baseImages:
+      - baseImage:
+          id: ubuntu-1604
+          shortDescription: v16.04
+          detailedDescription: Ubuntu v16.04
+          packageType: deb
+          templateFile: alicloud.json
+        virtualizationSettings:
+          - region: cn-hangzhou
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_16_04_64_20G_alibase_20190620.vhd
+            sshUserName: root
+          - region: cn-shanghai
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_16_04_64_20G_alibase_20190620.vhd
+            sshUserName: root
+          - region: eu-central-1
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_16_04_64_20G_alibase_20190620.vhd
+            sshUserName: root
+      - baseImage:
+          id: ubuntu-1804
+          shortDescription: v18.04
+          detailedDescription: Ubuntu v18.04
+          packageType: deb
+          templateFile: alicloud.json
+        virtualizationSettings:
+          - region: cn-hangzhou
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_18_04_64_20G_alibase_20190624.vhd
+            sshUserName: root
+          - region: cn-shanghai
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_18_04_64_20G_alibase_20190624.vhd
+            sshUserName: root
+          - region: eu-central-1
+            instanceType: ecs.c5.large
+            sourceImage: ubuntu_18_04_64_20G_alibase_20190624.vhd
+            sshUserName: root
+
 aws:
   # The property referenced below, AWS_ENABLED, is not set in the
   # 'unified config' supported by the spinnaker/spinnaker project. If you

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -35,6 +35,7 @@ if (project.plugins.hasPlugin('spinnaker.package')) {
     }
 
     configurationFile('/opt/rosco/config/rosco.yml')
+    configurationFile('/opt/rosco/config/packer/alicloud.json')
     configurationFile('/opt/rosco/config/packer/aws-chroot.json')
     configurationFile('/opt/rosco/config/packer/aws-ebs.json')
     configurationFile('/opt/rosco/config/packer/azure-linux.json')

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco
 
 import com.netflix.spinnaker.rosco.config.RoscoPackerConfigurationProperties
 import com.netflix.spinnaker.rosco.jobs.config.LocalJobConfig
+import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration
 import com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
 import com.netflix.spinnaker.rosco.providers.docker.config.RoscoDockerConfiguration
@@ -52,6 +53,7 @@ import javax.servlet.Filter
 @Import([
   WebConfig,
   ServiceConfig,
+  RoscoAliCloudConfiguration,
   RoscoAWSConfiguration,
   RoscoAzureConfiguration,
   RoscoDockerConfiguration,


### PR DESCRIPTION
This is a new provider used to build VM images on the [Alibaba Cloud](https://www.alibabacloud.com/). This PR add two template `alicloud.json` and `alicloud-multi.json` to build VM image in single and multiple regions.