### PR TITLE
chore(packer): upgrade packer binary to 1.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test && \
   dpkg -i ./rosco-web/build/distributions/*.deb && \
   mkdir /packer && \
   cd /packer && \
-  wget https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip && \
+  wget https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip && \
   apt-get install unzip -y && \
-  unzip packer_1.3.2_linux_amd64.zip && \
+  unzip packer_1.3.5_linux_amd64.zip && \
   rm -rf /workdir
 
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -9,9 +9,9 @@ COPY ./rosco-web/config/packer /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl && \
-  wget https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip && \
-  unzip packer_1.3.2_linux_amd64.zip && \
-  rm packer_1.3.2_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip && \
+  unzip packer_1.3.5_linux_amd64.zip && \
+  rm packer_1.3.5_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,7 +12,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 install_packer() {
-  PACKER_VERSION="1.3.2"
+  PACKER_VERSION="1.3.5"
   local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then


### PR DESCRIPTION
Turns out packer 1.3.2-1.3.4 have a lot of crash issues and builders filtering do not work.

spinnaker/spinnaker#4114