### PR TITLE
fix(bake/helm): use --set instead of --set-string

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -54,7 +54,7 @@ public class HelmTemplateUtils extends TemplateUtils {
       for (Map.Entry<String, Object> entry : overrides.entrySet()) {
         overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
       }
-      command.add("--set-string");
+      command.add("--set");
       command.add(overrideList.stream().collect(Collectors.joining(",")));
     }
 


### PR DESCRIPTION
using `--set` instead of `--set-string` ensures that values of different types get injected into into the chart properly. the most common use case for this is values that are used as `bool` in templates. Previously, these values would cause errors because they weren't properly converted.
