### PR TITLE
feat(packer): set custom repository per base image

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeOptions.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeOptions.groovy
@@ -30,6 +30,7 @@ class BakeOptions {
     BakeRequest.PackageType packageType
     String templateFile
     BakeRequest.OsType osType = BakeRequest.OsType.linux
+    String customRepository
   }
 
   static class Selected {

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -197,7 +197,9 @@ abstract class CloudProviderBakeHandler {
 
     def parameterMap = buildParameterMap(region, virtualizationSettings, imageName, bakeRequest, appVersionStr)
 
-    if (debianRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.DEB) {
+    if (selectedOptions.baseImage.customRepository) {
+      parameterMap.repository = selectedOptions.baseImage.customRepository
+    } else if (debianRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.DEB) {
       parameterMap.repository = debianRepository
     } else if (yumRepository && selectedOptions.baseImage.packageType == BakeRequest.PackageType.RPM) {
       parameterMap.repository = yumRepository

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -10,6 +10,7 @@ trait TestDefaults {
   static final String PACKAGES_NAME = "kato nflx-djangobase-enhanced_0.1-h12.170cdbd_all mongodb"
   static final String NUPKG_PACKAGES_NAME = "googlechrome javaruntime"
   static final String DEBIAN_REPOSITORY = "http://some-debian-repository"
+  static final String DEBIAN_CUSTOM_REPOSITORY = "http://some-custom-debian-repository"
   static final String YUM_REPOSITORY = "http://some-yum-repository"
   static final String CHOCOLATEY_REPOSITORY = "http://some-chocolatey-repository"
   static final CloudProviderType DOCKER_CLOUD_PROVIDER = BakeRequest.CloudProviderType.docker

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -29,6 +29,8 @@ packer:
 # debianRepository: http://dl.bintray.com/spinnaker/ospackages trusty main;http://other.repo.com/repo/packages trusty main
 # yumRepository: https://jfrog.bintray.com/yum/repos/some-package
 # chocolateyRepository: https://chocolatey.org/api/v2/
+# This general repository can be override at BaseImage level using customRepository entry
+
 
 defaultCloudProviderType: aws
 
@@ -136,6 +138,8 @@ aws:
         # You can specify the templateFile used for this baseImage.
         # If not specified, the default templateFile will be used.
         templateFile: aws-ebs.json
+        # You can specify a different repository for this baseImage.
+        # customRepository: http://dl.bintray.com/spinnaker/ospackages bionic main
       virtualizationSettings:
       - region: us-east-1
         virtualizationType: hvm


### PR DESCRIPTION
* feat(packer): set custom repository per base image

Right now there is the posibility to add one repository per package type (deb/rpm)
this collides when trying to setup multiple flavours/versions repositories for the
same package type.

e.g. When baking with Ubuntu you can only setup one repository index (xenial, bionic)
this forces you to put in the same repository index all packages no matter which
version are they intented to be.

With this patch, you can add a customRepository property per BaseImage with overwrites the
debianRepository/yumRepository/chocolateyRepository global config entries, this provides
more granularity on the repository configuration.

https://github.com/spinnaker/spinnaker/issues/4894