### PR TITLE
fix(bakeManifest): revert to set-string

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -71,7 +71,7 @@ public class HelmTemplateUtils extends TemplateUtils {
       for (Map.Entry<String, Object> entry : overrides.entrySet()) {
         overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
       }
-      command.add("--set");
+      command.add("--set-string");
       command.add(overrideList.stream().collect(Collectors.joining(",")));
     }
 


### PR DESCRIPTION
reverts a change introduced in #418 where we went from using
`--set-string` to `--set`. This change caused backwards incompaitble
changes because the parser for `--set` in helm coerces integers into
floats when it injects them into templates. `--set-string` was
introduced to fix this in helm 2.