### PR TITLE
fix(bakeManifest): helm --set option

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestRequest.java
@@ -11,4 +11,5 @@ import lombok.EqualsAndHashCode;
 public class HelmBakeManifestRequest extends BakeManifestRequest {
   String namespace;
   List<Artifact> inputArtifacts;
+  boolean rawOverrides;
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -71,7 +71,8 @@ public class HelmTemplateUtils extends TemplateUtils {
       for (Map.Entry<String, Object> entry : overrides.entrySet()) {
         overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
       }
-      command.add("--set-string");
+      String overrideOption = request.isRawOverrides() ? "--set" : "--set-string";
+      command.add(overrideOption);
       command.add(overrideList.stream().collect(Collectors.joining(",")));
     }
 


### PR DESCRIPTION
adds an option to toggle between `--set` and `--set-string`. we recently
had to revert a commit which changed `--set-string` to `--set` and
introduced a breaking change. this keeps the default behavior of
`--set-string` but allows users to choose which option they want to use.