### PR TITLE
fix(helm): Fix baking of helm artifacts (#442)

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -12,5 +12,9 @@ dependencies {
   implementation "org.yaml:snakeyaml:1.25"
 
   implementation "com.squareup.retrofit:retrofit"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -14,7 +14,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.xml.bind.DatatypeConverter;
 import org.springframework.stereotype.Component;
 
@@ -90,13 +92,22 @@ public class HelmTemplateUtils extends TemplateUtils {
     }
   }
 
+  @Nonnull
+  private String uniqueKey(Artifact artifact) {
+    if (artifact.getReference() != null) {
+      return artifact.getReference();
+    }
+    if (artifact.getName() != null) {
+      return String.format(
+          "%s-%s", artifact.getName(), Optional.ofNullable(artifact.getVersion()).orElse(""));
+    }
+    throw new InvalidRequestException("Input artifact has empty 'name' and 'reference' fields.");
+  }
+
   protected Path downloadArtifactToTmpFile(BakeManifestEnvironment env, Artifact artifact)
       throws IOException {
-    if (artifact.getReference() == null) {
-      throw new InvalidRequestException("Input artifact has an empty 'reference' field.");
-    }
-    File targetFile =
-        env.getStagingPath().resolve(nameFromReference(artifact.getReference())).toFile();
+    String uniqueKey = uniqueKey(artifact);
+    File targetFile = env.getStagingPath().resolve(nameFromReference(uniqueKey)).toFile();
     downloadArtifact(artifact, targetFile);
     return targetFile.toPath();
   }

--- a/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.manifests.helm;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
+import com.netflix.spinnaker.rosco.manifests.BakeManifestEnvironment;
+import com.netflix.spinnaker.rosco.services.ClouddriverService;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import retrofit.client.Response;
+import retrofit.mime.TypedByteArray;
+
+@RunWith(JUnitPlatform.class)
+final class HelmTemplateUtilsTest {
+  @Test
+  public void nullReferenceTest() throws IOException {
+    ClouddriverService clouddriverService = mock(ClouddriverService.class);
+    HelmTemplateUtils helmTemplateUtils = new HelmTemplateUtils(clouddriverService);
+    Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
+
+    HelmBakeManifestRequest bakeManifestRequest = new HelmBakeManifestRequest();
+    bakeManifestRequest.setInputArtifacts(ImmutableList.of(chartArtifact));
+    bakeManifestRequest.setOverrides(ImmutableMap.of());
+
+    when(clouddriverService.fetchArtifact(chartArtifact)).thenReturn(emptyRepsonse());
+    try (BakeManifestEnvironment env = BakeManifestEnvironment.create()) {
+      BakeRecipe recipe = helmTemplateUtils.buildBakeRecipe(env, bakeManifestRequest);
+    }
+  }
+
+  private Response emptyRepsonse() {
+    return new Response("", 200, "", ImmutableList.of(), new TypedByteArray(null, new byte[0]));
+  }
+}


### PR DESCRIPTION
Manual cherry pick of #442; the only conflict was the imports at the top of `HelmTemplateUtils.java`.

We currently throw an exception if a helm artifact doesn't have a reference. We're only using that reference to generate a file name to use when downloading the artifact; helm artifacts don't actually
need a reference.

Fix this by just falling back to the name-version if there is no reference defined.