### PR TITLE
fix(kustomize): fetch new artifacts using the same version

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -192,6 +192,7 @@ public class KustomizeTemplateUtils {
   private Artifact artifactFromBase(Artifact artifact, String reference, String name) {
     return Artifact.builder()
         .reference(reference)
+        .version(artifact.getVersion())
         .name(name)
         .type(artifact.getType())
         .artifactAccount(artifact.getArtifactAccount())


### PR DESCRIPTION
if it's not set, it'll fetch from `master`, which is unintended.