### PR TITLE
feat(kustomize): support git/repo artifact in kustomize bake manifest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Tue Oct 01 16:31:16 UTC 2019
+#Wed Oct 16 19:40:47 UTC 2019
 enablePublishing=false
-korkVersion=6.11.0
 spinnakerGradleVersion=7.0.2
+korkVersion=6.12.1
 org.gradle.parallel=true

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "commons-io:commons-io"
+  implementation "org.apache.commons:commons-compress:1.14"
   implementation "org.yaml:snakeyaml:1.25"
 
   implementation "com.squareup.retrofit:retrofit"

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloader.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloader.java
@@ -18,8 +18,11 @@ package com.netflix.spinnaker.rosco.manifests;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 
 public interface ArtifactDownloader {
-  void downloadArtifact(Artifact artifact, Path targetFile) throws IOException;
+  InputStream downloadArtifact(Artifact artifact) throws IOException;
+
+  void downloadArtifactToFile(Artifact artifact, Path targetFile) throws IOException;
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -29,22 +29,20 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
         retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
     if (response.getBody() == null) {
       throw new IOException("Failure to fetch artifact: empty response");
-    } else {
-      try (InputStream inputStream = response.getBody().in()) {
-        return inputStream;
+    }
+    return response.getBody().in();
+  }
+
+  public void downloadArtifactToFile(Artifact artifact, Path targetFile) throws IOException {
+    try (OutputStream outputStream = Files.newOutputStream(targetFile)) {
+      try (InputStream inputStream = downloadArtifact(artifact)) {
+        IOUtils.copy(inputStream, outputStream);
       } catch (IOException e) {
         throw new IOException(
             String.format(
                 "Failed to read input stream of downloaded artifact: %s. Error: %s",
                 artifact, e.getMessage()));
       }
-    }
-  }
-
-  public void downloadArtifactToFile(Artifact artifact, Path targetFile) throws IOException {
-    try (OutputStream outputStream = Files.newOutputStream(targetFile)) {
-      InputStream inputStream = downloadArtifact(artifact);
-      IOUtils.copy(inputStream, outputStream);
     } catch (RetrofitError e) {
       throw new IOException(
           String.format("Failed to download artifact: %s. Error: %s", artifact, e.getMessage()));

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -23,7 +23,18 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
     this.clouddriverService = clouddriverService;
   }
 
-  public void downloadArtifact(Artifact artifact, Path targetFile) throws IOException {
+  public InputStream downloadArtifact(Artifact artifact) throws IOException {
+    Response response =
+        retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
+    if (response.getBody() != null) {
+      return response.getBody().in();
+    } else {
+      log.error("Failure to fetch artifact: empty response");
+      return null;
+    }
+  }
+
+  public void downloadArtifactToFile(Artifact artifact, Path targetFile) throws IOException {
     try (OutputStream outputStream = Files.newOutputStream(targetFile)) {
       Response response =
           retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -93,7 +93,7 @@ public class HelmTemplateUtils {
       throws IOException {
     String fileName = UUID.randomUUID().toString();
     Path targetPath = env.resolvePath(fileName);
-    artifactDownloader.downloadArtifact(artifact, targetPath);
+    artifactDownloader.downloadArtifactToFile(artifact, targetPath);
     return targetPath;
   }
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeBakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeBakeManifestRequest.java
@@ -25,4 +25,5 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class KustomizeBakeManifestRequest extends BakeManifestRequest {
   private Artifact inputArtifact;
+  private String kustomizeFilePath;
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -192,6 +192,7 @@ public class KustomizeTemplateUtils {
   private Artifact artifactFromBase(Artifact artifact, String reference, String name) {
     return Artifact.builder()
         .reference(reference)
+        .version(artifact.getVersion())
         .name(name)
         .type(artifact.getType())
         .artifactAccount(artifact.getArtifactAccount())

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -109,8 +109,8 @@ public class KustomizeTemplateUtils {
       BakeManifestEnvironment env, KustomizeBakeManifestRequest request, Artifact artifact)
       throws IOException {
     // This is a redundant check for now, but it's here for when we soon remove the old logic of
-    // building from
-    // a github/file artifact type and instead, only support the git/repo artifact type
+    // building from a github/file artifact type and instead, only support the git/repo artifact
+    // type
     if (!"git/repo".equals(artifact.getType())) {
       throw new IllegalArgumentException("The inputArtifact should be of type \"git/repo\".");
     }
@@ -151,7 +151,7 @@ public class KustomizeTemplateUtils {
 
       ArchiveEntry archiveEntry;
       while ((archiveEntry = tarArchiveInputStream.getNextEntry()) != null) {
-        Path archiveEntryOutput = outputPath.resolve(archiveEntry.getName());
+        Path archiveEntryOutput = validateArchiveEntry(archiveEntry.getName(), outputPath);
         if (archiveEntry.isDirectory()) {
           if (!Files.exists(archiveEntryOutput)) {
             Files.createDirectory(archiveEntryOutput);
@@ -160,9 +160,15 @@ public class KustomizeTemplateUtils {
           Files.copy(tarArchiveInputStream, archiveEntryOutput);
         }
       }
-    } catch (Exception e) {
-      System.out.println(e);
     }
+  }
+
+  private static Path validateArchiveEntry(String archiveEntryName, Path outputPath) {
+    Path entryPath = outputPath.resolve(archiveEntryName);
+    if (!entryPath.normalize().startsWith(outputPath)) {
+      throw new IllegalStateException("Attempting to create a file outside of the staging path.");
+    }
+    return entryPath;
   }
 
   protected void downloadArtifactToTmpFileStructure(

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
@@ -48,7 +48,7 @@ final class ArtifactDownloaderImplTest {
     try (ArtifactDownloaderImplTest.AutoDeletingFile file = new AutoDeletingFile()) {
       when(clouddriverService.fetchArtifact(testArtifact))
           .thenReturn(successfulResponse(testContent));
-      artifactDownloader.downloadArtifact(testArtifact, file.path);
+      artifactDownloader.downloadArtifactToFile(testArtifact, file.path);
 
       Assertions.assertThat(file.path).hasContent(testContent);
     }
@@ -63,7 +63,7 @@ final class ArtifactDownloaderImplTest {
       when(clouddriverService.fetchArtifact(testArtifact))
           .thenThrow(RetrofitError.networkError("", new IOException("timeout")))
           .thenReturn(successfulResponse(testContent));
-      artifactDownloader.downloadArtifact(testArtifact, file.path);
+      artifactDownloader.downloadArtifactToFile(testArtifact, file.path);
 
       Assertions.assertThat(file.path).hasContent(testContent);
     }


### PR DESCRIPTION
This adds support for `git/repo` as an artifact type for a kustomize bake. This is a work in progress involving changes to other services as well, so we're leaving in the old logic (baking from a github/file artifact) until the rest of the PRs are merged. 

@ezimanyi PTAL?