### PR TITLE
fix(dockerfile): correct hashicorp packer path to 1.4.4

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -7,7 +7,7 @@ COPY --from=compile /compiled_sources/rosco-web/config/packer       /opt/rosco/c
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl && \
-  wget https://releases.hashicorp.com/packer/1.4.2/packer_1.4.4_linux_amd64.zip && \
+  wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip && \
   unzip packer_1.4.4_linux_amd64.zip && \
   rm packer_1.4.4_linux_amd64.zip
 


### PR DESCRIPTION
Fixes regression introduced in [this PR](https://github.com/spinnaker/rosco/pull/450) that broke the build.