### PR TITLE
fix(artifact): improve error messaging for failed artifact downl…

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 @Component
@@ -30,8 +31,16 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
       if (response.getBody() != null) {
         try (InputStream inputStream = response.getBody().in()) {
           IOUtils.copy(inputStream, outputStream);
+        } catch (IOException e) {
+          throw new IOException(
+              String.format(
+                  "Failed to read input stream of downloaded artifact: %s. Error: %s",
+                  artifact, e.getMessage()));
         }
       }
+    } catch (RetrofitError e) {
+      throw new IOException(
+          String.format("Failed to download artifact: %s. Error: %s", artifact, e.getMessage()));
     }
   }
 }


### PR DESCRIPTION
Related to: https://github.com/spinnaker/spinnaker/issues/4752

When running a Bake (Manifest) stage with the Helm or Kustomize template renderers, Orca calls out to Rosco, which calls out to Clouddriver to download the input artifact. If the download fails, a non-specific "500" message is surfaced in Deck. This change adds two explicit catch blocks to the `ArtifactDownloaderImpl` so that the full artifact and error message are surfaced in Deck. I am still not sure why Retrofit and/or Orca's handling of Retrofit errors only surfaces "500" by default, since Clouddriver does throw a more explicit error when it fails to download an artifact -- it seems like when the error is passed between multiple microservices to get back to Orca, the message on the body of the Retrofit response is lost.

Before:
![Xq78dvzCrRj](https://user-images.githubusercontent.com/15936279/67319804-6a4da780-f4db-11e9-9b5c-5f4846efa93e.png)

After:
![GjwCF9fUGn5](https://user-images.githubusercontent.com/15936279/67319828-720d4c00-f4db-11e9-9bbd-e2037fdcaf62.png)
