### PR TITLE
fix(gce): Remove recently unpublished 'trusty' base image, add 'bionic'

### DIFF
--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -398,14 +398,6 @@ google:
     #   virtualizationSettings:
     #     sourceImage: ubuntu-1404-trusty-v20170517
     - baseImage:
-        id: trusty
-        shortDescription: v14.04
-        detailedDescription: Ubuntu Trusty Tahr v14.04
-        packageType: deb
-        isImageFamily: true
-      virtualizationSettings:
-        sourceImageFamily: ubuntu-1404-lts
-    - baseImage:
         id: xenial
         shortDescription: v16.04
         detailedDescription: Ubuntu Xenial Xerus v16.04
@@ -413,6 +405,14 @@ google:
         isImageFamily: true
       virtualizationSettings:
         sourceImageFamily: ubuntu-1604-lts
+    - baseImage:
+        id: bionic
+        shortDescription: v18.04
+        detailedDescription: Ubuntu Bionic Beaver v18.04
+        packageType: deb
+        isImageFamily: true
+      virtualizationSettings:
+        sourceImageFamily: ubuntu-1804-lts
 
 huaweicloud:
   # The property referenced below, HUAWEICLOUD_ENABLED, is not set in the


### PR DESCRIPTION
It appears the `ubuntu-1404-lts` image family was unpublished, causing our builds to break.  This will need to be cherry picked into 1.17, too.