### PR TITLE
fix(gce): Hardcode Trusty GCE image in halconfig/images.yml

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -200,12 +200,13 @@ google:
     baseImages:
     - baseImage:
         id: trusty
-        shortDescription: v14.04
-        detailedDescription: Ubuntu Trusty Tahr v14.04
+        shortDescription: v14.04 - Deprecated
+        detailedDescription: Ubuntu Trusty Tahr v14.04 - Deprecated.
         packageType: deb
-        isImageFamily: true
+        isImageFamily: false
       virtualizationSettings:
-        sourceImageFamily: ubuntu-1404-lts
+        # Last published release of Trusty. Has been removed for 1.18 and above.
+        sourceImage: ubuntu-1404-trusty-v20191107
     - baseImage:
         id: xenial
         shortDescription: v16.04
@@ -214,3 +215,11 @@ google:
         isImageFamily: true
       virtualizationSettings:
         sourceImageFamily: ubuntu-1604-lts
+    - baseImage:
+        id: bionic
+        shortDescription: v18.04
+        detailedDescription: Ubuntu Bionic Beaver v18.04
+        packageType: deb
+        isImageFamily: true
+      virtualizationSettings:
+        sourceImageFamily: ubuntu-1804-lts


### PR DESCRIPTION
Need to make the same change as https://github.com/spinnaker/rosco/pull/471 except in `halyard/` in order for releases to pick them up.