### PR TITLE
fix(gce): Remove Trusty GCE image in halconfig/images.yml, add Bionic

### DIFF
--- a/halconfig/images.yml
+++ b/halconfig/images.yml
@@ -199,14 +199,6 @@ google:
   bakeryDefaults:
     baseImages:
     - baseImage:
-        id: trusty
-        shortDescription: v14.04
-        detailedDescription: Ubuntu Trusty Tahr v14.04
-        packageType: deb
-        isImageFamily: true
-      virtualizationSettings:
-        sourceImageFamily: ubuntu-1404-lts
-    - baseImage:
         id: xenial
         shortDescription: v16.04
         detailedDescription: Ubuntu Xenial Xerus v16.04
@@ -214,3 +206,11 @@ google:
         isImageFamily: true
       virtualizationSettings:
         sourceImageFamily: ubuntu-1604-lts
+    - baseImage:
+        id: bionic
+        shortDescription: v18.04
+        detailedDescription: Ubuntu Bionic Beaver v18.04
+        packageType: deb
+        isImageFamily: true
+      virtualizationSettings:
+        sourceImageFamily: ubuntu-1804-lts


### PR DESCRIPTION
Need to apply https://github.com/spinnaker/rosco/pull/470 to `halyard/images.yml` to have it work with releases.