### PR TITLE
refactor(artifacts): Use builder to create artifacts

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -122,17 +122,16 @@ abstract class CloudProviderBakeHandler {
    * but it could be useful to override this method for specific providers.
    */
   def Artifact produceArtifactDecorationFrom(BakeRequest bakeRequest, BakeRecipe bakeRecipe, Bake bakeDetails, String cloudProvider, String region) {
-    Artifact bakedArtifact = new Artifact(
-      name: bakeRecipe?.name,
-      type: "${cloudProvider}/image",
-      location: region,
-      reference: getArtifactReference(bakeRequest, bakeDetails),
-      metadata: [
+    Artifact bakedArtifact = Artifact.builder()
+      .name(bakeRecipe?.name)
+      .type("${cloudProvider}/image")
+      .location(region)
+      .reference(getArtifactReference(bakeRequest, bakeDetails))
+      .metadata([
         build_info_url: bakeRequest?.build_info_url,
-        build_number: bakeRequest?.build_number
-      ],
-      uuid: bakeDetails.id
-    )
+        build_number: bakeRequest?.build_number])
+      .uuid(bakeDetails.id)
+      .build()
 
     return bakedArtifact
   }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -219,10 +219,11 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
       }
 
       if (foundAmisCreated && line =~ AMI_EXTRACTOR) {
-        Artifact a = new Artifact()
-        a.type = AMI_TYPE
-        a.location = line.split(": ").first()
-        a.reference = line.split(": ").last()
+        Artifact a = Artifact.builder()
+          .type(AMI_TYPE)
+          .location(line.split(": ").first())
+          .reference(line.split(": ").last())
+          .build()
         artifacts.add(a)
       }
     }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -143,16 +143,15 @@ class BakePollerSpec extends Specification implements TestDefaults {
       def jobExecutorMock = Mock(JobExecutor)
       def bakeRequest = new BakeRequest(build_info_url: SOME_BUILD_INFO_URL)
       def bakeRecipe = new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
-      def bakedArtifact = new Artifact(
-        name: bakeRecipe.name,
-        version: bakeRecipe.version,
-        type: "${DOCKER_CLOUD_PROVIDER}/image",
-        reference: AMI_ID,
-        metadata: [
+      def bakedArtifact = Artifact.builder()
+        .name(bakeRecipe.name)
+        .version(bakeRecipe.version)
+        .type("${DOCKER_CLOUD_PROVIDER}/image")
+        .reference(AMI_ID)
+        .metadata([
           build_info_url: bakeRequest.build_info_url,
-          build_number: bakeRequest.build_number
-        ]
-      )
+          build_number: bakeRequest.build_number])
+        .build()
       def bakeDetails = new Bake(id: JOB_ID, ami: AMI_ID, image_name: IMAGE_NAME, artifact: bakedArtifact)
       def decoratedBakeDetails = new Bake(id: JOB_ID, ami: AMI_ID, image_name: IMAGE_NAME, artifact: bakedArtifact)
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
@@ -27,18 +27,17 @@ class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults
 
   void 'we should create a fully decorated artifact if all base data is present'() {
     setup:
-      def expectedArtifact = new Artifact (
-        name: SOME_BAKE_RECIPE.name,
-        version: null,
-        location: SOME_REGION,
-        type: "${SOME_CLOUD_PROVIDER}/image",
-        reference: SOME_BAKE_DETAILS.ami,
-        metadata: [
+      def expectedArtifact = Artifact.builder()
+        .name(SOME_BAKE_RECIPE.name)
+        .version(null)
+        .location(SOME_REGION)
+        .type("${SOME_CLOUD_PROVIDER}/image")
+        .reference(SOME_BAKE_DETAILS.ami)
+        .metadata([
           build_info_url: SOME_BAKE_REQUEST.build_info_url,
-          build_number: SOME_BAKE_REQUEST.build_number
-        ],
-        uuid: SOME_BAKE_DETAILS.id
-      )
+          build_number: SOME_BAKE_REQUEST.build_number])
+        .uuid(SOME_BAKE_DETAILS.id)
+        .build()
 
       @Subject
       CloudProviderBakeHandler bakeHandler = Spy(CloudProviderBakeHandler)


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact were deprecated in spinnaker/kork#429. Replace their usages with a builder.