### PR TITLE
chore(release): Use buster-slim instead of alpine as the base OS

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre-slim
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/rosco-web/build/install/rosco /opt/rosco
 COPY --from=compile /compiled_sources/rosco-web/config              /opt/rosco


### PR DESCRIPTION
The Alpine builds haven't been updated in months. See
spinnaker/spinnaker#5204.