### PR TITLE
chore(jobexecutor): log stdout/err for failed bakes to debug integrat…

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -168,6 +168,8 @@ class JobExecutorLocal implements JobExecutor {
           } else {
             bakeStatus.state = BakeStatus.State.CANCELED
             bakeStatus.result = BakeStatus.Result.FAILURE
+            log.info("StdOut for failed job $jobId: $outputContent")
+            log.info("StdErr for failed job $jobId: $logsContent")
           }
 
           jobIdToHandlerMap.remove(jobId)


### PR DESCRIPTION
…ion test failures

The GCE bake and deploy integration test has been intermittently failing all week on all branches. The `packer build` command is failing, but I can't determine why from the Rosco logs (`State for xxx changed with exit code 1` is all we get). This change adds logging so we can hopefully determine the root cause of the intermittent failures.