### PR TITLE
chore(dependencies): Reverting Spring Boot 2.2 upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Tue Dec 17 00:36:10 UTC 2019
+#Tue Dec 10 18:16:34 UTC 2019
 enablePublishing=false
+korkVersion=7.4.0
 spinnakerGradleVersion=7.0.2
-korkVersion=7.3.0
 org.gradle.parallel=true

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/config/RedisConnectionInfo.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/config/RedisConnectionInfo.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.rosco.persistence.config
 
 import groovy.transform.ToString
 import redis.clients.jedis.Protocol
-import redis.clients.jedis.util.JedisURIHelper
+import redis.clients.util.JedisURIHelper
 
 @ToString(includeNames = true)
 class RedisConnectionInfo {


### PR DESCRIPTION
Revert "chore(dependencies): Upgrade Spring Boot to 2.2.1 (#468)"
This reverts commit c2b3a74d