### PR TITLE
chore(vulnerabilities): resolve CVEs and other security issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ allprojects {
       jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8187'
     }
   }
+  configurations.all {
+    resolutionStrategy {
+      force group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.+' // Remove CVE-2019-17267, CVE-2019-16335, CVE-2019-14540, CVE-2019-14540 and CVE-2019-17531 , upgrade jackson-databind dependency
+    }
+  }
 }
 
 subprojects {


### PR DESCRIPTION
- Remove CVE-2019-17267, CVE-2019-16335, CVE-2019-14540, CVE-2019-14540 and CVE-2019-17531 , upgrade jackson-databind dependency
