### PR TITLE
chore(build): Install Helm3 Binary to Rosco Container Image

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -13,6 +13,14 @@ RUN apk --no-cache add --update bash wget curl openssl openjdk8-jre && \
 
 ENV PATH "/packer:$PATH"
 
+# Install Helm 3
+RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3
+
+# Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
   ./get && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -13,6 +13,14 @@ RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre && \
 
 ENV PATH "/packer:$PATH"
 
+# Install Helm 3
+RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3
+
+# Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
   ./get && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -13,6 +13,14 @@ RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl
 
 ENV PATH "/packer:$PATH"
 
+# Install Helm 3
+RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3
+
+# Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
   ./get && \

--- a/Dockerfile.ubuntu-java8
+++ b/Dockerfile.ubuntu-java8
@@ -13,6 +13,14 @@ RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget unzip curl 
 
 ENV PATH "/packer:$PATH"
 
+# Install Helm 3
+RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3
+
+# Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
   ./get && \


### PR DESCRIPTION
Install Helm 3 Binary alongside Helm 2.

Part of https://github.com/spinnaker/spinnaker/issues/5474

## Test Plan

```
$ docker build -t compile -f Dockerfile.compile .
$ docker build -t slim -f Dockerfile.slim .
$ docker run --rm slim helm version
Client: &version.Version{SemVer:"v2.16.3", GitCommit:"1ee0254c86d4ed6887327dabed7aa7da29d7eb0d", GitTreeState:"clean"}
Error: Get http://localhost:8080/api/v1/namespaces/kube-system/pods?labelSelector=app%3Dhelm%2Cname%3Dtiller: dial tcp 127.0.0.1:8080: connect: connection refused
$ docker run --rm slim helm3 version
version.BuildInfo{Version:"v3.1.0", GitCommit:"b29d20baf09943e134c2fa5e1e1cab3bf93315fa", GitTreeState:"clean", GoVersion:"go1.13.7"}
```