### PR TITLE
feat(helm): Implement Support for Selecting Between Helm2 and Helm3 B…

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/BakeManifestRequest.java
@@ -14,6 +14,7 @@ public class BakeManifestRequest {
 
   public enum TemplateRenderer {
     HELM2,
+    HELM3,
     KUSTOMIZE;
 
     @JsonCreator

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/config/RoscoHelmConfigurationProperties.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/config/RoscoHelmConfigurationProperties.java
@@ -22,6 +22,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("helm")
 @Data
 public class RoscoHelmConfigurationProperties {
-  String v3ExecutablePath = "helm3";
-  String v2ExecutablePath = "helm";
+  private String v3ExecutablePath = "helm3";
+  private String v2ExecutablePath = "helm";
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/config/RoscoHelmConfigurationProperties.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/config/RoscoHelmConfigurationProperties.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Grab Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.manifests.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("helm")
+@Data
+public class RoscoHelmConfigurationProperties {
+  String v3ExecutablePath = "helm3";
+  String v2ExecutablePath = "helm";
+}

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -12,7 +12,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelmBakeManifestService extends BakeManifestService<HelmBakeManifestRequest> {
   private final HelmTemplateUtils helmTemplateUtils;
-  private static final String HELM_TYPE = "HELM2";
+  private static final String HELM2_TYPE = "HELM2";
+  private static final String HELM3_TYPE = "HELM3";
 
   public HelmBakeManifestService(HelmTemplateUtils helmTemplateUtils, JobExecutor jobExecutor) {
     super(jobExecutor);
@@ -26,7 +27,7 @@ public class HelmBakeManifestService extends BakeManifestService<HelmBakeManifes
 
   @Override
   public boolean handles(String type) {
-    return type.toUpperCase().equals(HELM_TYPE);
+    return HELM2_TYPE.equals(type.toUpperCase()) || HELM3_TYPE.equals(type.toUpperCase());
   }
 
   public Artifact bake(HelmBakeManifestRequest bakeManifestRequest) throws IOException {

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestService.java
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.rosco.manifests.helm;
 
+import static com.netflix.spinnaker.rosco.manifests.BakeManifestRequest.TemplateRenderer;
+
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.jobs.JobExecutor;
@@ -12,8 +15,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelmBakeManifestService extends BakeManifestService<HelmBakeManifestRequest> {
   private final HelmTemplateUtils helmTemplateUtils;
-  private static final String HELM2_TYPE = "HELM2";
-  private static final String HELM3_TYPE = "HELM3";
+  private static final ImmutableSet<String> supportedTemplates =
+      ImmutableSet.of(TemplateRenderer.HELM2.toString(), TemplateRenderer.HELM3.toString());
 
   public HelmBakeManifestService(HelmTemplateUtils helmTemplateUtils, JobExecutor jobExecutor) {
     super(jobExecutor);
@@ -27,7 +30,7 @@ public class HelmBakeManifestService extends BakeManifestService<HelmBakeManifes
 
   @Override
   public boolean handles(String type) {
-    return HELM2_TYPE.equals(type.toUpperCase()) || HELM3_TYPE.equals(type.toUpperCase());
+    return supportedTemplates.contains(type);
   }
 
   public Artifact bake(HelmBakeManifestRequest bakeManifestRequest) throws IOException {

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -57,11 +57,21 @@ public class HelmTemplateUtils {
 
     List<String> command = new ArrayList<>();
     String executable = getHelmExecutableForRequest(request);
+
+    // Helm `template` subcommands are slightly different
+    // helm 2: helm template <chart> --name <release name>
+    // helm 3: helm template <release name> <chart>
+    // Other parameters such as --namespace, --set, and --values are the same
     command.add(executable);
     command.add("template");
-    command.add(templatePath.toString());
-    command.add("--name");
-    command.add(request.getOutputName());
+    if (HelmBakeManifestRequest.TemplateRenderer.HELM2.equals(request.getTemplateRenderer())) {
+      command.add(templatePath.toString());
+      command.add("--name");
+      command.add(request.getOutputName());
+    } else {
+      command.add(request.getOutputName());
+      command.add(templatePath.toString());
+    }
 
     String namespace = request.getNamespace();
     if (namespace != null && !namespace.isEmpty()) {

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader;
 import com.netflix.spinnaker.rosco.manifests.BakeManifestEnvironment;
+import com.netflix.spinnaker.rosco.manifests.config.RoscoHelmConfigurationProperties;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -34,7 +35,10 @@ final class HelmTemplateUtilsTest {
   @Test
   public void nullReferenceTest() throws IOException {
     ArtifactDownloader artifactDownloader = mock(ArtifactDownloader.class);
-    HelmTemplateUtils helmTemplateUtils = new HelmTemplateUtils(artifactDownloader);
+    RoscoHelmConfigurationProperties helmConfigurationProperties =
+        mock(RoscoHelmConfigurationProperties.class);
+    HelmTemplateUtils helmTemplateUtils =
+        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
     Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
 
     HelmBakeManifestRequest bakeManifestRequest = new HelmBakeManifestRequest();

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.rosco
 
 import com.netflix.spinnaker.rosco.config.RoscoPackerConfigurationProperties
 import com.netflix.spinnaker.rosco.jobs.config.LocalJobConfig
+import com.netflix.spinnaker.rosco.manifests.config.RoscoHelmConfigurationProperties
 import com.netflix.spinnaker.rosco.providers.alicloud.config.RoscoAliCloudConfiguration
 import com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration
 import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration
@@ -62,6 +63,7 @@ import javax.servlet.Filter
   RoscoHuaweiCloudConfiguration,
   RoscoOracleConfiguration,
   RoscoPackerConfigurationProperties,
+  RoscoHelmConfigurationProperties,
   LocalJobConfig
 ])
 @EnableAutoConfiguration(exclude = [BatchAutoConfiguration, GroovyTemplateAutoConfiguration])


### PR DESCRIPTION
Part of spinnaker/spinnaker#5474

This PR does the following

- Add HELM3 Template Renderer type
- Add indirection in `HelmTemplateUtils` to select Helm 3 binary if HELM3 renderer is chosen
- Allow both Helm binary path to be customised using e.g `helm.v2ExecutablePath`