### PR TITLE
feat(bakery/Azure): Changes to extract shared-image-gallery image name from logs

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -32,6 +32,7 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
 
   private static final String IMAGE_NAME_TOKEN = "ManagedImageName: "
   private static final String IMAGE_ID_TOKEN = "ManagedImageId: "
+  private static final String SIG_IMAGE_ID_TOKEN = "ManagedImageSharedImageGalleryId: "
 
   ImageNameFactory imageNameFactory = new ImageNameFactory()
 
@@ -65,10 +66,14 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
       // Sample for the image name and image id in logs
       // ManagedImageName: hello-karyon-rxnetty-all-20190128114007-ubuntu-1604
       // ManagedImageId: /subscriptions/faab228d-df7a-4086-991e-e81c4659d41a/resourceGroups/zhqqi-sntest/providers/Microsoft.Compute/images/hello-karyon-rxnetty-all-20190128114007-ubuntu-1604
+      // ManagedImageSharedImageGalleryId: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/galleries/test-gallery/images/test-image/versions/1.0.9
+
       if (line.startsWith(IMAGE_NAME_TOKEN)) {
         imageName = line.substring(IMAGE_NAME_TOKEN.size())
       } else if (line.startsWith(IMAGE_ID_TOKEN)) {
         ami = line.substring(IMAGE_ID_TOKEN.size())
+      } else if (line.startsWith(SIG_IMAGE_ID_TOKEN)) {
+        ami = line.substring(SIG_IMAGE_ID_TOKEN.size())
       }
     }
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -193,6 +193,78 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
     }
   }
 
+  void 'can scrape packer logs for image name in SIG'() {
+    setup:
+    @Subject
+    AzureBakeHandler azureBakeHandler = new AzureBakeHandler()
+
+    when:
+    def logsContent =
+            "==> azure-arm: Deleting the temporary OS disk ...\n" +
+                    "==> azure-arm:  -> OS Disk             : 'https://lgpackervms.blob.core.windows.net/images/pkroswfvmtp50x8.vhd'\n" +
+                    "==> azure-arm:\n" +
+                    "==> azure-arm: Cleanup requested, deleting resource group ...\n" +
+                    "==> azure-arm: Error deleting resource group.  Please delete it manually.\n" +
+                    "==> azure-arm:\n" +
+                    "==> azure-arm: Name: packer-Resource-Group-wfvmtp50x8\n" +
+                    "==> azure-arm: Error: azure#updatePollingState: Azure Polling Error - Unable to obtain polling URI for DELETE : StatusCode=0\n" +
+                    "==> azure-arm: Resource group has been deleted.\n" +
+                    "Build 'azure-arm' finished.\n" +
+                    "\n" +
+                    "==> Builds finished. The artifacts of successful builds are:\n" +
+                    "--> azure-arm: Azure.ResourceManagement.VMImage:\n" +
+                    "\n" +
+                    "StorageAccountLocation: westus\n" +
+                    "ManagedImageName: pkroswfvmtp50x8\n" +
+                    "ManagedImageSharedImageGalleryId: pkroswfvmtp50x8id"
+
+
+    Bake bake = azureBakeHandler.scrapeCompletedBakeResults(null, "123", logsContent)
+
+    then:
+    with (bake) {
+      id == "123"
+      ami == "pkroswfvmtp50x8id"
+      image_name == "pkroswfvmtp50x8"
+    }
+  }
+
+  void 'can scrape packer logs for image name for windows in SIG'() {
+    setup:
+    @Subject
+    AzureBakeHandler azureBakeHandler = new AzureBakeHandler()
+
+    when:
+    def logsContent =
+            "==> azure-arm: Deleting the temporary OS disk ...\n" +
+                    "==> azure-arm:  -> OS Disk             : 'https://lgpackervms.blob.core.windows.net/images/pkroswfvmtp50x8.vhd'\n" +
+                    "==> azure-arm:\n" +
+                    "==> azure-arm: Cleanup requested, deleting resource group ...\n" +
+                    "==> azure-arm: Error deleting resource group.  Please delete it manually.\n" +
+                    "==> azure-arm:\n" +
+                    "==> azure-arm: Name: packer-Resource-Group-wfvmtp50x8\n" +
+                    "==> azure-arm: Error: azure#updatePollingState: Azure Polling Error - Unable to obtain polling URI for DELETE : StatusCode=0\n" +
+                    "==> azure-arm: Resource group has been deleted.\n" +
+                    "Build 'azure-arm' finished.\n" +
+                    "\n" +
+                    "==> Builds finished. The artifacts of successful builds are:\n" +
+                    "--> azure-arm: Azure.ResourceManagement.VMImage:\n" +
+                    "\n" +
+                    "StorageAccountLocation: westus\n" +
+                    "ManagedImageName: pkroswfvmtp50x8\n" +
+                    "ManagedImageSharedImageGalleryId: pkroswfvmtp50x8id"
+
+
+    Bake bake = azureBakeHandler.scrapeCompletedBakeResults(null, "123", logsContent)
+
+    then:
+    with (bake) {
+      id == "123"
+      ami == "pkroswfvmtp50x8id"
+      image_name == "pkroswfvmtp50x8"
+    }
+  }
+
   void 'template file name data is serialized as expected'() {
     setup:
       @Subject


### PR DESCRIPTION
This PR is for resolving   https://github.com/spinnaker/spinnaker/issues/5448.
When using Azure provider if we have a custom packer template which creates shared gallery image , the "Image" output variable still reference the managed image which also gets created as a part of the shared image gallery version. It is possible to create shared image gallery images by adding extension attributes in bake stage json as it is passed on to the packer template as variables. However the rosco azure bake handler only scraps Managed image id which is also created in the due process. But if one were to create shared gallery image, then the idea is that we don't need managed image id reference anymore. So the output could reference the shared image gallery id and this could be in turn used for deploy. This PR is for that. 
Samples changes to packer json and extended attributes in bake stage are as below
Packer changes to include shared image gallery
```
                          "shared_image_gallery": {
				"subscription": "{{user `azure_sig_src_subscription`}}",
				"resource_group": "{{user `azure_sig_src_resource_group`}}",
				"gallery_name": "{{user `azure_sig_src_gallery_name`}}",
				"image_name": "{{user `azure_sig_src_image_name`}}",
				"image_version": "{{user `azure_sig_src_image_version`}}"
			},

			"shared_image_gallery_destination": {
				"resource_group":"{{user `azure_sig_dst_resource_group`}}",
				"gallery_name": "{{user `azure_sig_dst_gallery_name`}}",
				"image_name": "{{user `azure_sig_dst_image_name`}}",
				"image_version": "{{user `azure_sig_dst_image_version`}}",
				"replication_regions": "{{user `azure_sig_replication_regions`}}"
			},

			"managed_image_name": "{{user `azure_sig_dst_image_name`}}-{{user `azure_sig_dst_image_version`}}",
			"managed_image_resource_group_name":"{{user `azure_sig_dst_resource_group`}}",
```
Bake stage additional attributes could be added to extended attribute as below
```
     "extendedAttributes": {
          "azure_sig_dst_gallery_name": "${trigger.parameters.azure_sig_dst_gallery_name}",
          "azure_sig_dst_image_name": "${trigger.parameters.azure_sig_dst_image_name}",
          "azure_sig_dst_image_version": "${trigger.parameters.azure_sig_dst_image_version}",
          "azure_sig_dst_resource_group": "${trigger.parameters.azure_sig_dst_resource_group}",
          "azure_sig_dst_packer_resource_group" : "${trigger.parameters.azure_sig_dst_packer_resource_group}",
          "azure_sig_replication_regions": "${trigger.parameters.azure_sig_replication_regions}",
          "azure_sig_src_gallery_name": "${trigger.parameters.azure_sig_src_gallery_name}",
          "azure_sig_src_image_name": "${trigger.parameters.azure_sig_src_image_name}",
          "azure_sig_src_image_version": "${trigger.parameters.azure_sig_src_image_version}",
          "azure_sig_src_resource_group": "${trigger.parameters.azure_sig_src_resource_group}",
          "azure_sig_src_subscription": "${trigger.parameters.azure_sig_src_subscription}",
          "azure_sig_vm_size": "${trigger.parameters.azure_sig_vm_size}"
        },

```

