### PR TITLE
fix(kustomize): allow kustomize to fetch git artifacts longer

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloader.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloader.java
@@ -24,5 +24,7 @@ import java.nio.file.Path;
 public interface ArtifactDownloader {
   InputStream downloadArtifact(Artifact artifact) throws IOException;
 
+  InputStream downloadArtifact(Artifact artifact, int maxRetries) throws IOException;
+
   void downloadArtifactToFile(Artifact artifact, Path targetFile) throws IOException;
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -25,8 +25,13 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
   }
 
   public InputStream downloadArtifact(Artifact artifact) throws IOException {
+    return downloadArtifact(artifact, 5);
+  }
+
+  public InputStream downloadArtifact(Artifact artifact, int maxRetries) throws IOException {
     Response response =
-        retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
+        retrySupport.retry(
+            () -> clouddriverService.fetchArtifact(artifact), maxRetries, 1000, true);
     if (response.getBody() == null) {
       throw new IOException("Failure to fetch artifact: empty response");
     }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -122,7 +122,8 @@ public class KustomizeTemplateUtils {
 
     InputStream inputStream;
     try {
-      inputStream = artifactDownloader.downloadArtifact(artifact);
+      // maxRetries = 7 will give you abour 1 min to download artifacts
+      inputStream = artifactDownloader.downloadArtifact(artifact, 7);
     } catch (IOException e) {
       throw new IOException("Failed to download git/repo artifact: " + e.getMessage(), e);
     }


### PR DESCRIPTION
TL;DR:
When kustomization file was provided from a git repo, larger, and more historic, repositories can take a substantial amount of time to clone. `jGit` does not have sufficient functions to speedup fetching process, thus the bake process will likely to exceed the current timeout (~15s), and fail.

issue details:
https://github.com/spinnaker/spinnaker/issues/5402

work around details:
https://github.com/spinnaker/spinnaker/issues/5402#issuecomment-615172419

Overloading `downloadArtifact` with `maxRetries=7` will allow it to poll for ~1 min.

BTW, loading a configurable number from config files will be graceful.