### PR TITLE
fix(rosco): Update Hashicorp Packer version in rosco to 1.4.5 (bp #555)

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -7,9 +7,9 @@ COPY halconfig/packer              /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl openjdk8-jre && \
-  wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip && \
-  unzip packer_1.4.4_linux_amd64.zip && \
-  rm packer_1.4.4_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
+  unzip packer_1.4.5_linux_amd64.zip && \
+  rm packer_1.4.5_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -7,9 +7,9 @@ COPY halconfig/packer              /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre && \
-  wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip && \
-  unzip packer_1.4.4_linux_amd64.zip && \
-  rm packer_1.4.4_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
+  unzip packer_1.4.5_linux_amd64.zip && \
+  rm packer_1.4.5_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,9 +7,9 @@ COPY halconfig/packer              /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl && \
-  wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip && \
-  unzip packer_1.4.4_linux_amd64.zip && \
-  rm packer_1.4.4_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
+  unzip packer_1.4.5_linux_amd64.zip && \
+  rm packer_1.4.5_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/Dockerfile.ubuntu-java8
+++ b/Dockerfile.ubuntu-java8
@@ -7,9 +7,9 @@ COPY halconfig/packer              /opt/rosco/config/packer
 WORKDIR /packer
 
 RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget unzip curl && \
-  wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip && \
-  unzip packer_1.4.4_linux_amd64.zip && \
-  rm packer_1.4.4_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
+  unzip packer_1.4.5_linux_amd64.zip && \
+  rm packer_1.4.5_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,7 +12,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 install_packer() {
-  PACKER_VERSION="1.4.4"
+  PACKER_VERSION="1.4.5"
   local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then


### PR DESCRIPTION
Requesting a backport of this packer patch which should fix a problem with our bakery hanging intermittently when running in parallel & using WinRM.