### PR TITLE
config(core): Push Halyard default configs down to core

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains a skeleton rosco config to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `rosco-web/config/rosco.yml`
+or set a default in the code reading the config property.

--- a/halconfig/rosco.yml
+++ b/halconfig/rosco.yml
@@ -3,9 +3,3 @@
 server:
   port: ${services.rosco.port:8087}
   address: ${services.rosco.host:localhost}
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}
-
-rosco:
-  configDir: /opt/rosco/config/packer

--- a/rosco-web/config/rosco.yml
+++ b/rosco-web/config/rosco.yml
@@ -2,10 +2,13 @@ server:
   port: 8087
 
 rosco:
-  configDir: /some/path/to/config/packer
+  configDir: /opt/rosco/config/packer
   jobs:
     local:
       timeoutMinutes: 30
+
+redis:
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
 
 spectator:
   applicationName: ${spring.application.name}


### PR DESCRIPTION
As with the other microservices, let's push defaults that were being set by Halyard down to the core so that the defaults are the same for everyone.

Halyard was setting the redis connection based on the services.redis value; push that down to the base. Users who were manually setting this before will not be affected as they will override this value; users who did not set this at all before will still fall back to the localhost:6379 which is the fallback at the point we read it.

Halyard was also setting the configDir to /opt/packer/config. The default in the base config was placeholder /some/path/to/config/packer; replace this with what Halyard was setting. I suppose that if someone was actually putting their templates in /some/path/to/config/packer then this would break them until they explicitly set that value, but I can't imagine that's actually the case.