### PR TITLE
fix(tests): Fix tests failing on artifact

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-korkVersion=7.42.13
+korkVersion=7.43.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.1.1
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
@@ -62,9 +62,9 @@ class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults
 
     where:
       bakeRequest       | bakeRecipe       | expectedName          | expectedVersion      | expectedReference | expectedMetadata
-      null              | null             | null                  | null                 | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
-      null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
-      SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | ["build_info_url": SOME_BUILD_INFO_URL, "build_number": SOME_BUILD_NR]
+      null              | null             | ""                    | ""                   | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
+      null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | ""                   | SOME_AMI_ID       | ["build_info_url": null, "build_number": null]
+      SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | ""                   | SOME_AMI_ID       | ["build_info_url": SOME_BUILD_INFO_URL, "build_number": SOME_BUILD_NR]
 
   }
 

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -173,7 +173,7 @@ public class KustomizeTemplateUtils {
 
   protected void downloadArtifactToTmpFileStructure(
       BakeManifestEnvironment env, Artifact artifact, String referenceBaseURL) throws IOException {
-    if (artifact.getReference() == null) {
+    if (artifact.getReference() == null || artifact.getReference().isEmpty()) {
       throw new InvalidRequestException("Input artifact has an empty 'reference' field.");
     }
     Path artifactFileName = Paths.get(extractArtifactName(artifact, referenceBaseURL));

--- a/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsSpec.groovy
+++ b/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsSpec.groovy
@@ -151,7 +151,7 @@ class HelmTemplateUtilsSpec extends Specification {
         def helmProperties = Mock(RoscoHelmConfigurationProperties)
         def helmTemplateUtils = new HelmTemplateUtils(artifactDownloader, helmProperties)
         def request = new HelmBakeManifestRequest()
-        def artifact = Mock(Artifact)
+        def artifact = Artifact.builder().build()
         request.inputArtifacts = [artifact]
         request.namespace = "default"
         request.overrides = [:]


### PR DESCRIPTION
An upcoming kork bump is making artifact null-safe by setting fields to empty string. Fix the couple of places that expected null.