### PR TITLE
refactor(artifacts): Mutate a copy of kustomization artifact

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtils.java
@@ -259,8 +259,12 @@ public class KustomizeTemplateUtils {
       // look like a folder then we know it should be downloaded later.
       if (isFolder(evaluate)) {
         Path tmpBase = Paths.get(FilenameUtils.normalize(base.resolve(evaluate).toString()));
-        artifact.setName(tmpBase.toString());
-        filesToDownload.addAll(getFilesFromArtifact(artifact, referenceBaseURL, tmpBase, filename));
+        filesToDownload.addAll(
+            getFilesFromArtifact(
+                artifact.toBuilder().name(tmpBase.toString()).build(),
+                referenceBaseURL,
+                tmpBase,
+                filename));
       } else {
         filesToDownload.add(referenceBase.concat(File.separator).concat(evaluate));
       }


### PR DESCRIPTION
In an upcoming kork release, the Artifact class will become immutable to reduce the confusing class of bugs where artifact mutations are accidentally done on a copy (primarily in orca). There were very few places we were mutating artifacts, and they can all be replaced by returning a new artifact with the desired changes.

The only place in rosco that is mutating artifacts is the kustomize bake. As it walks down the dependent kustomizations, it keeps track of where it is in an artifact.name field. This change just updates the code to pass a new artifact with the desired name down the recursion rather than mutating the existing one.

The one side effect here is that the input Artifact that we are baking will no longer have its name end up as the most deeply-nested kustomization that it refers to and will keep the name it started with.

I doubt the intention in any case was to have the incoming artifact be mutated in this way so that its name (but nothing else) referred to the last-processed of its nested customiztions. But as the name doesn't affect the downloading or baking logic it looks like this was not an issue (and updating this to operate on a copy and leave the original artifact as is should not have any user-visible effect).