### PR TITLE
fix(packer/aws): update aws image name expression to handle packer 1.4

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -40,7 +40,7 @@ import java.util.regex.Pattern
 public class AWSBakeHandler extends CloudProviderBakeHandler {
 
   private static final String IMAGE_NAME_TOKEN = "amazon-(chroot|ebs): Creating the AMI:"
-  private static final String UNENCRYPTED_IMAGE_NAME_TOKEN = "(==> |)amazon-(chroot|ebs): Creating unencrypted AMI"
+  private static final String UNENCRYPTED_IMAGE_NAME_TOKEN = "(==> |)amazon-(chroot|ebs): Creating( unencrypted)? AMI"
   // AMI_EXTRACTOR finds amis from the format produced by packer ie:
   // eu-north-1: ami-076cf277a86b6e5b4
   // us-east-1: ami-2c014644


### PR DESCRIPTION
As of Packer 1.4 `unencrypted` no longer part of the log line:
https://github.com/hashicorp/packer/commit/f03cbd8a1016ba8aa01aa7975717b9bcaf386bf1#diff-0bde66b340110f862b5241a0051e7fb1R33

Updating the expression to match either case.