### PR TITLE
feature(bakery): allow dynamic packer templates in the bakery

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -72,8 +72,14 @@ class BakeRequest {
   @ApiModelProperty("The image owner organization")
   String organization
 
-  @ApiModelProperty("The explicit packer template to use, instead of resolving one from rosco's configuration")
+  @ApiModelProperty("The explicit packer template file to use, instead of resolving one from rosco's configuration")
   String template_file_name
+  @ApiModelProperty("The packer template. When provided, `template_file_name` is ignored")
+  String template
+  @ApiModelProperty("Only provide this parameter if you provide the `template` parameter, and that template requires packer to run as root")
+  boolean template_requires_root
+  @ApiModelProperty("template variables to pass to packer command, only provide this in conjuction with the `template` parameter. Otherwise, either use `var_file_name` or let Rosco calculate the parameters automatically")
+  Map<String, String> template_vars
   @ApiModelProperty("A map of key/value pairs to add to the packer command")
   Map extended_attributes
   @ApiModelProperty("The name of a json file containing key/value pairs to add to the packer command (must be in the same location as the template file)")

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandler.groovy
@@ -91,6 +91,9 @@ abstract class CloudProviderBakeHandler {
         base_ami,
         ami_name,
         template_file_name,
+        template,
+        template_requires_root,
+        template_vars,
         var_file_name,
       ].findAll { it }
 
@@ -161,13 +164,22 @@ abstract class CloudProviderBakeHandler {
 
   /**
    * Returns the command that should be prepended to the shell command passed to the container.
+   * Used when a static template file name is provided
    */
-  String getBaseCommand(String templateName) {
+  List<String> getBaseCommand(String templateFileName) {
     if (templatesNeedingRoot) {
-      return templatesNeedingRoot.contains(templateName) ? "sudo" : ""
+      return templatesNeedingRoot.contains(templateFileName) ? ["sudo"] : [""]
     } else {
-      return ""
+      return [""]
     }
+  }
+
+  /**
+   * Returns the command that should be prepended to the shell command passed to the container.
+   * Used when a dynamic template is provided
+   */
+  List<String> getBaseCommand(String template, boolean template_requires_root) {
+    return ["echo", "'$template'", "|", template_requires_root ? "sudo" : ""]
   }
 
   /**
@@ -201,7 +213,7 @@ abstract class CloudProviderBakeHandler {
     // separately
     def packagesParameter = imageNameFactory.buildPackagesParameter(packageType, osPackageNames)
 
-    def parameterMap = buildParameterMap(region, virtualizationSettings, imageName, bakeRequest, appVersionStr)
+    def parameterMap = bakeRequest.template_vars ?: buildParameterMap(region, virtualizationSettings, imageName, bakeRequest, appVersionStr)
 
     if (selectedOptions.baseImage.customRepository) {
       parameterMap.repository = selectedOptions.baseImage.customRepository
@@ -236,14 +248,22 @@ abstract class CloudProviderBakeHandler {
       }
     }
 
-    def finalTemplateFileName = bakeRequest.template_file_name ?: getTemplateFileName(selectedOptions.baseImage)
-    def finaltemplateFilePath = "$configDir/$finalTemplateFileName"
+    def finalTemplateFilePath
+    def baseCommand
+    if (!bakeRequest.template) {
+      def finalTemplateFileName = bakeRequest.template_file_name ?: getTemplateFileName(selectedOptions.baseImage)
+      finalTemplateFilePath = "$configDir/$finalTemplateFileName"
+      baseCommand = getBaseCommand(finalTemplateFileName)
+    } else {
+      // read the template from stdin
+      finalTemplateFilePath = "-"
+      baseCommand = getBaseCommand(bakeRequest.template, bakeRequest.template_requires_root)
+    }
     def finalVarFileName = bakeRequest.var_file_name ? "$configDir/$bakeRequest.var_file_name" : null
-    def baseCommand = getBaseCommand(finalTemplateFileName)
     def packerCommand = packerCommandFactory.buildPackerCommand(baseCommand,
                                                                 parameterMap,
                                                                 finalVarFileName,
-                                                                finaltemplateFilePath)
+                                                                finalTemplateFilePath)
 
     return new BakeRecipe(name: imageName, version: appVersionStr, command: packerCommand)
   }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactory.groovy
@@ -24,11 +24,11 @@ class LocalJobFriendlyPackerCommandFactory implements PackerCommandFactory {
   @Autowired RoscoPackerConfigurationProperties roscoPackerConfigurationProperties
 
   @Override
-  List<String> buildPackerCommand(String baseCommand,
+  List<String> buildPackerCommand(List<String> baseCommand,
                                   Map<String, String> parameterMap,
                                   String absoluteVarFilePath,
                                   String absoluteTemplateFilePath) {
-    def packerCommand = [baseCommand, "packer", "build", "-color=false"]
+    def packerCommand = [*baseCommand, "packer", "build", "-color=false"]
     if (roscoPackerConfigurationProperties.timestamp) {
       packerCommand.add("-timestamp-ui")
     }

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerCommandFactory.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackerCommandFactory.groovy
@@ -21,6 +21,6 @@ interface PackerCommandFactory {
   /**
    * Serialize passed parameters into a tokenized command string suitable for launching packer.
    */
-  List<String> buildPackerCommand(String baseCommand, Map<String, String> parameterMap, String absoluteVarFilePath, String absoluteTemplateFilePath)
+  List<String> buildPackerCommand(List<String> baseCommand, Map<String, String> parameterMap, String absoluteVarFilePath, String absoluteTemplateFilePath)
 
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
@@ -207,7 +207,7 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 
 
@@ -248,7 +248,7 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for ubuntu, and overriding template filename'() {
@@ -288,7 +288,7 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/somePackerTemplate.json")
   }
 
   void 'produces packer command with all required parameters for ubuntu, and adding extended attributes'() {
@@ -330,7 +330,7 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 
   void 'throws exception when virtualization settings are not found for specified operating system'() {
@@ -470,7 +470,7 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including copy_to multiple regions as extended_attribute'() {
@@ -523,6 +523,6 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandlerSpec.groovy
@@ -491,7 +491,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for amzn, using default vm type'() {
@@ -533,7 +533,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for amzn, with sudo'() {
@@ -598,7 +598,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("sudo", parameterMap, null, "$configDir/aws-chroot.json")
+      1 * packerCommandFactoryMock.buildPackerCommand(["sudo"], parameterMap, null, "$configDir/aws-chroot.json")
   }
 
   void 'produces packer command with all required parameters for ubuntu, using default vm type, and overriding base ami'() {
@@ -641,7 +641,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for ubuntu, using explicit vm type'() {
@@ -683,7 +683,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for ubuntu, using explicit vm type, and overriding template filename'() {
@@ -726,7 +726,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/somePackerTemplate.json")
   }
 
   void 'produces packer command with all required parameters for ubuntu, using explicit vm type, and adding extended attributes'() {
@@ -771,7 +771,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'sends spot_price_auto_product iff spot_price is set to auto'() {
@@ -850,7 +850,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
     1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
     1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-    1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+    1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty, using explicit vm type'() {
@@ -892,7 +892,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including appversion, build_host and build_info_url for trusty'() {
@@ -943,7 +943,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including upgrade'() {
@@ -987,7 +987,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer (Windows) command with all required parameters'() {
@@ -1030,7 +1030,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
     1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, NUPKG_PACKAGE_TYPE) >> null
     1 * imageNameFactoryMock.buildPackagesParameter(NUPKG_PACKAGE_TYPE, osPackages) >> NUPKG_PACKAGES_NAME
-    1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$operatingSystemVirtualizationSettings.baseImage.templateFile")
+    1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$operatingSystemVirtualizationSettings.baseImage.templateFile")
   }
 
   void 'throws exception when virtualization settings are not found for specified operating system'() {
@@ -1256,7 +1256,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including copy_to multiple regions as extended_attribute'() {
@@ -1312,7 +1312,7 @@ class AWSBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$awsBakeryDefaults.templateFile")
   }
 
   static class NoSleepRetry extends RetrySupport {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -278,7 +278,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/azure-linux.json")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/azure-linux.json")
   }
 
   void 'produces packer command with all required parameters for windows'() {
@@ -326,7 +326,7 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
     1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
     1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, NUPKG_PACKAGE_TYPE) >> null
     1 * imageNameFactoryMock.buildPackagesParameter(NUPKG_PACKAGE_TYPE, osPackages) >> NUPKG_PACKAGES_NAME
-    1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/azure-windows-2012-r2.json")
+    1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/azure-windows-2012-r2.json")
   }
 
   void 'Create proper azure_image_name'() {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -182,7 +182,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty'() {
@@ -225,7 +225,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for centos'() {
@@ -268,7 +268,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, RPM_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including build_host and docker_target_image_tag for trusty'() {
@@ -315,7 +315,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, [osPackage]) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, [osPackage], DEB_PACKAGE_TYPE) >> SOME_MILLISECONDS
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including docker specific parameters'() {
@@ -364,7 +364,7 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> targetImageTag
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetQualifiedImageName
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$dockerBakeryDefaults.templateFile")
   }
 
   void 'Create parameter map with minimal bakeRequest'() {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -291,7 +291,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for centos'() {
@@ -339,7 +339,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(RPM_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for precise, and overriding base image'() {
@@ -388,7 +388,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for precise, and overriding template filename'() {
@@ -437,7 +437,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/somePackerTemplate.json")
   }
 
   void 'produces packer command with all required parameters for precise, and adding extended attributes'() {
@@ -488,7 +488,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for precise, and overrides native attributes via extended attributes'() {
@@ -542,7 +542,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for precise, and respects optional subnetwork config default'() {
@@ -593,7 +593,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty'() {
@@ -641,7 +641,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty, including network project id'() {
@@ -692,7 +692,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including appversion, build_host and build_info_url for trusty'() {
@@ -749,7 +749,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, [osPackage]) >> fullyQualifiedPackageName
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for trusty and reflects specified account_name'() {
@@ -799,7 +799,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for xenial, when source image family is configured'() {
@@ -847,7 +847,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for xenial, and overriding base image even though source image family is configured'() {
@@ -896,7 +896,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for yakkety, preferring source image when both source image and source image family are configured'() {
@@ -944,7 +944,7 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
       1 * packerArtifactServiceMock.writeArtifactsToFile(bakeRequest.request_id, _) >> Paths.get(ARTIFACT_FILE_NAME)
       1 * packerManifestServiceMock.getManifestFileName(bakeRequest.request_id) >> MANIFEST_FILE_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$gceBakeryDefaults.templateFile")
   }
 
   void 'throws exception when virtualization settings are not found for specified operating system'() {

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/huaweicloud/HuaweiCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/huaweicloud/HuaweiCloudBakeHandlerSpec.groovy
@@ -196,7 +196,7 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for ubuntu, and overriding base ami'() {
@@ -237,7 +237,7 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters for ubuntu, and overriding template filename'() {
@@ -278,7 +278,7 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/somePackerTemplate.json")
   }
 
   void 'produces packer command with all required parameters for ubuntu, and adding extended attributes'() {
@@ -321,7 +321,7 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 
   void 'throws exception when virtualization settings are not found for specified operating system'() {
@@ -462,7 +462,7 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 
   void 'produces packer command with all required parameters including copy_to multiple regions as extended_attribute'() {
@@ -516,6 +516,6 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
       1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
       1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-      1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
+      1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/tencentcloud/TencentCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/tencentcloud/TencentCloudBakeHandlerSpec.groovy
@@ -180,7 +180,7 @@ class TencentCloudBakeHandlerSpec extends Specification implements TestDefaults 
         1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
         1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
         1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-        1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
+        1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
     }
 
     void 'produces packer command with all required parameters for ubuntu, and overriding template filename'() {
@@ -221,7 +221,7 @@ class TencentCloudBakeHandlerSpec extends Specification implements TestDefaults 
         1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
         1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
         1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-        1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/somePackerTemplate.json")
+        1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/somePackerTemplate.json")
     }
 
     void 'produces packer command with all required parameters for ubuntu, and adding extended attributes'() {
@@ -264,7 +264,7 @@ class TencentCloudBakeHandlerSpec extends Specification implements TestDefaults 
         1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
         1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> null
         1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> PACKAGES_NAME
-        1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
+        1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
     }
 
     void 'throws exception when virtualization settings are not found for specified operating system'() {
@@ -402,7 +402,7 @@ class TencentCloudBakeHandlerSpec extends Specification implements TestDefaults 
         1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
         1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
         1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-        1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
+        1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
     }
 
     void 'produces packer command with all required parameters including copy_to multiple regions as extended_attribute'() {
@@ -453,6 +453,6 @@ class TencentCloudBakeHandlerSpec extends Specification implements TestDefaults 
         1 * imageNameFactoryMock.buildImageName(bakeRequest, osPackages) >> targetImageName
         1 * imageNameFactoryMock.buildAppVersionStr(bakeRequest, osPackages, DEB_PACKAGE_TYPE) >> appVersionStr
         1 * imageNameFactoryMock.buildPackagesParameter(DEB_PACKAGE_TYPE, osPackages) >> fullyQualifiedPackageName
-        1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
+        1 * packerCommandFactoryMock.buildPackerCommand([""], parameterMap, null, "$configDir/$tencentCloudBakeryDefaults.templateFile")
     }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/LocalJobFriendlyPackerCommandFactorySpec.groovy
@@ -29,9 +29,9 @@ class LocalJobFriendlyPackerCommandFactorySpec extends Specification implements 
 
     where:
       something | baseCommand | expectedPackerCommand
-      "sudo"    | "sudo"      | ["sudo", "packer", "build", "-color=false", "-var", "something=sudo"]
+      "sudo"    | ["sudo"]    | ["sudo", "packer", "build", "-color=false", "-var", "something=sudo"]
       "null"    | null        | ["packer", "build", "-color=false", "-var", "something=null"]
-      "empty"   | ""          | ["packer", "build", "-color=false", "-var", "something=empty"]
+      "empty"   | [""]        | ["packer", "build", "-color=false", "-var", "something=empty"]
   }
 
   @Unroll
@@ -42,7 +42,7 @@ class LocalJobFriendlyPackerCommandFactorySpec extends Specification implements 
       ]
 
     when:
-      def packerCommand = packerCommandFactory.buildPackerCommand("", parameterMap, varFile, "")
+      def packerCommand = packerCommandFactory.buildPackerCommand([""], parameterMap, varFile, "")
 
     then:
       packerCommand == expectedPackerCommand
@@ -58,7 +58,7 @@ class LocalJobFriendlyPackerCommandFactorySpec extends Specification implements 
   void "packerCommand includes parameter with non-quoted string"() {
 
     when:
-    def packerCommand = packerCommandFactory.buildPackerCommand("", parameterMap, null, "")
+    def packerCommand = packerCommandFactory.buildPackerCommand([""], parameterMap, null, "")
 
     then:
     packerCommand == expectedPackerCommand
@@ -73,7 +73,7 @@ class LocalJobFriendlyPackerCommandFactorySpec extends Specification implements 
     setup:
 
     when:
-      def packerCommand = packerCommandFactory.buildPackerCommand("", parameterMap, null, "")
+      def packerCommand = packerCommandFactory.buildPackerCommand([""], parameterMap, null, "")
       def jobRequest = new JobRequest(tokenizedCommand: packerCommand, maskedParameters: maskedPackerParameters, jobId: SOME_UUID)
       def commandLine = new CommandLine(jobRequest.tokenizedCommand[0])
       def arguments = (String []) Arrays.copyOfRange(jobRequest.tokenizedCommand.toArray(), 1, jobRequest.tokenizedCommand.size())


### PR DESCRIPTION
Currently, we can only read templates that were added to rosco by halyard.

This PR allows to pass templates dynamically.

Since the `packer build` command only accepts a file, I `echo` the template, and pass that output to the command. So it looks like:

```
echo {"my_values": "5"} | packer build -
```
