### PR TITLE
fix(dependencies): depend on only swagger-annotations for compile

### DIFF
--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -17,8 +17,8 @@ configurations.all {
 dependencies {
   compile project(":rosco-core")
   compile project(":rosco-manifests")
-  implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.swagger:swagger-annotations"
 
   implementation "org.codehaus.groovy:groovy-all"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"


### PR DESCRIPTION
kork-runtime brings in kork-swagger for the runtime component configuration