### PR TITLE
fix(bake): Fix error when updating artifacts after bake

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/executor/BakePoller.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.rosco.executor
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.api.BakeStatus
@@ -224,9 +225,11 @@ class BakePoller implements ApplicationListener<ContextRefreshedEvent> {
               )
 
               // The artifacts that are found does not have the complete context as they are extracted from the logs.
-              bakeDetails.artifacts.each {
-                it.name = bakeRecipe.name
-                it.uuid = bakeDetails.id
+              bakeDetails.artifacts = bakeDetails.artifacts.collect { Artifact artifact ->
+                artifact.toBuilder()
+                  .name(bakeRecipe.name)
+                  .uuid(bakeDetails.id)
+                  .build()
               }
 
               bakeStore.updateBakeDetails(bakeDetails)

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.api.BakeStatus
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe
+import com.netflix.spinnaker.rosco.persistence.BakeStore
 import com.netflix.spinnaker.rosco.persistence.RedisBackedBakeStore
 import com.netflix.spinnaker.rosco.providers.CloudProviderBakeHandler
 import com.netflix.spinnaker.rosco.providers.registry.CloudProviderBakeHandlerRegistry
@@ -174,6 +175,54 @@ class BakePollerSpec extends Specification implements TestDefaults {
       1 * bakeStoreMock.retrieveBakeRequestById(JOB_ID) >> bakeRequest
       1 * bakeStoreMock.retrieveBakeRecipeById(JOB_ID) >> bakeRecipe
       1 * bakeStoreMock.updateBakeDetails(decoratedBakeDetails)
+  }
+
+  void 'sets the name and uuid on baked artifacts'() {
+    setup:
+    def bakedArtifact = Artifact.builder()
+            .type("aws/image")
+            .location("eu-north-1")
+            .reference("ami-076cf277a86b6e5b4")
+            .build()
+
+    def bakeStoreMock = Mock(BakeStore) {
+      retrieveCloudProviderById(JOB_ID) >> BakeRequest.CloudProviderType.aws.toString()
+      retrieveRegionById(JOB_ID) >> SOME_REGION
+      retrieveBakeRequestById(JOB_ID) >> new BakeRequest(build_info_url: SOME_BUILD_INFO_URL)
+      retrieveBakeRecipeById(JOB_ID) >> new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
+    }
+
+    def cloudProviderBakeHandlerMock = Mock(CloudProviderBakeHandler) {
+      scrapeCompletedBakeResults(SOME_REGION, JOB_ID, _ as String) >> new Bake(id: JOB_ID, ami: AMI_ID, artifacts: [bakedArtifact])
+      produceArtifactDecorationFrom(_ as BakeRequest, _ as BakeRecipe, _ as Bake, _ as String, _ as String) >> bakedArtifact
+      deleteArtifactFile(_ as String) >> {}
+    }
+
+    def cloudProviderBakeHandlerRegistryMock = Mock(CloudProviderBakeHandlerRegistry) {
+      lookup(BakeRequest.CloudProviderType.aws) >> cloudProviderBakeHandlerMock
+    }
+
+    @Subject
+    def bakePoller = new BakePoller(
+            bakeStore: bakeStoreMock,
+            executor: Mock(JobExecutor),
+            cloudProviderBakeHandlerRegistry: cloudProviderBakeHandlerRegistryMock,
+            registry: new DefaultRegistry())
+
+    when:
+    bakePoller.completeBake(JOB_ID, LOGS_CONTENT)
+
+    then:
+    // TODO(ezimanyi): Fix this exception so that instead updateBakeDetails is called
+    thrown(ReadOnlyPropertyException.class)
+    0 * bakeStoreMock.updateBakeDetails(_ as Bake) >> { Bake bake ->
+      assert bake.getArtifacts().size() == 1
+      Artifact artifact = bake.getArtifacts().get(0)
+      assert artifact.getName() == SOME_BAKE_RECIPE_NAME
+      assert artifact.getUuid() == JOB_ID
+      assert artifact.getType() == "aws/image"
+      assert artifact.getReference() == "ami-076cf277a86b6e5b4"
+    }
   }
 
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -213,9 +213,7 @@ class BakePollerSpec extends Specification implements TestDefaults {
     bakePoller.completeBake(JOB_ID, LOGS_CONTENT)
 
     then:
-    // TODO(ezimanyi): Fix this exception so that instead updateBakeDetails is called
-    thrown(ReadOnlyPropertyException.class)
-    0 * bakeStoreMock.updateBakeDetails(_ as Bake) >> { Bake bake ->
+    1 * bakeStoreMock.updateBakeDetails(_ as Bake) >> { Bake bake ->
       assert bake.getArtifacts().size() == 1
       Artifact artifact = bake.getArtifacts().get(0)
       assert artifact.getName() == SOME_BAKE_RECIPE_NAME


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5998.

* test(bake): Add test exercising bake artifact handling

  There is currently no test that exercises the logic that updates the name and uuid on artifacts produced by a bake.  Add a test exercising this logic that currently fails and will be fixed in the next commit.

* fix(bake): Fix error when updating artifacts after bake

  When artifacts were made immutable, this usage was missed as it did not have tests (and was in groovy so compilation didn't catch it). Instead of mutating the artifacts, return copies with the appropriate fields changed.