### PR TITLE
fix(kustomize): Use 3.8.5 of kustomize with latest fixes to kustomize handling

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -24,7 +24,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   rm get
 
 RUN mkdir kustomize && \
-  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz|\
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.5/kustomize_v3.8.5_linux_amd64.tar.gz|\
   tar xvz -C kustomize/
 
 ENV PATH "kustomize:$PATH"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -24,7 +24,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   rm get
 
 RUN mkdir kustomize && \
-  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz|\
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.5/kustomize_v3.8.5_linux_amd64.tar.gz|\
   tar xvz -C kustomize/
 
 ENV PATH "kustomize:$PATH"


### PR DESCRIPTION
Encountered some bugs with kustomize 3.8.1 - this bumps to 3.8.5 with the latest fixes.