### PR TITLE
refactor(artifact downloader): Chain root cause when rethrowing exception

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -41,11 +41,12 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
         throw new IOException(
             String.format(
                 "Failed to read input stream of downloaded artifact: %s. Error: %s",
-                artifact, e.getMessage()));
+                artifact, e.getMessage()),
+            e);
       }
     } catch (RetrofitError e) {
       throw new IOException(
-          String.format("Failed to download artifact: %s. Error: %s", artifact, e.getMessage()));
+          String.format("Failed to download artifact: %s. Error: %s", artifact, e.getMessage()), e);
     }
   }
 }


### PR DESCRIPTION
* don't hide the root cause of artifact download failure to ease up troubleshooting