### PR TITLE
feat(provider/aws): Override AWS VPC/Subnet Ids from virtualization settings

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -166,11 +166,15 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
       parameterMap.aws_secret_key = awsBakeryDefaults.awsSecretKey
     }
 
-    if (awsBakeryDefaults.awsSubnetId) {
+    if (awsVirtualizationSettings.awsSubnetId) {
+      parameterMap.aws_subnet_id = awsVirtualizationSettings.awsSubnetId
+    } else if (awsBakeryDefaults.awsSubnetId) {
       parameterMap.aws_subnet_id = awsBakeryDefaults.awsSubnetId
     }
 
-    if (awsBakeryDefaults.awsVpcId) {
+    if (awsVirtualizationSettings.awsVpcId) {
+      parameterMap.aws_vpc_id = awsVirtualizationSettings.awsVpcId
+    } else if (awsBakeryDefaults.awsVpcId) {
       parameterMap.aws_vpc_id = awsBakeryDefaults.awsVpcId
     }
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
@@ -75,6 +75,8 @@ class RoscoAWSConfiguration {
     String winRmUserName
     String spotPrice
     String spotPriceAutoProduct
+    String awsVpcId
+    String awsSubnetId
   }
 
   static class AWSNamedImage {


### PR DESCRIPTION
This is part of resolving spinnaker/spinnaker#6182

This is allowing the VPC and Subnet Ids to be set in the virtualization settings with the following order of preference:
1. Extended attributes set in the UI using `aws_subnet_id` or `aws_vpc_id`
2. The `awsSubnetId` and `awsVpcId` settings of the `virtualizationSettings` (new)
3. The `awsSubnetId` and `awsVpcId` settings of the bakery defaults

I've opened this is a draft as I've not yet managed to get a local deployment of spinnaker running under WSL2 to test out an actual AMI bake using these settings.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
