### PR TITLE
feat(provider/aws): Override AWS VPC/Subnet Ids from virtualization settings

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -166,11 +166,15 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
       parameterMap.aws_secret_key = awsBakeryDefaults.awsSecretKey
     }
 
-    if (awsBakeryDefaults.awsSubnetId) {
+    if (awsVirtualizationSettings.awsSubnetId) {
+      parameterMap.aws_subnet_id = awsVirtualizationSettings.awsSubnetId
+    } else if (awsBakeryDefaults.awsSubnetId) {
       parameterMap.aws_subnet_id = awsBakeryDefaults.awsSubnetId
     }
 
-    if (awsBakeryDefaults.awsVpcId) {
+    if (awsVirtualizationSettings.awsVpcId) {
+      parameterMap.aws_vpc_id = awsVirtualizationSettings.awsVpcId
+    } else if (awsBakeryDefaults.awsVpcId) {
       parameterMap.aws_vpc_id = awsBakeryDefaults.awsVpcId
     }
 

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
@@ -75,6 +75,8 @@ class RoscoAWSConfiguration {
     String winRmUserName
     String spotPrice
     String spotPriceAutoProduct
+    String awsVpcId
+    String awsSubnetId
   }
 
   static class AWSNamedImage {


### PR DESCRIPTION
This is part of resolving spinnaker/spinnaker#6182

This is allowing the VPC and Subnet Ids to be set in the virtualization settings with the following order of preference:
1. Extended attributes set in the UI using `aws_subnet_id` or `aws_vpc_id`
2. The `awsSubnetId` and `awsVpcId` settings of the `virtualizationSettings` (new)
3. The `awsSubnetId` and `awsVpcId` settings of the bakery defaults

I've opened this is a draft as I've not yet managed to get a local deployment of spinnaker running under WSL2 to test out an actual AMI bake using these settings.
