### PR TITLE
chore(logs): allow anonymous clouddriver artifact fetching

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.rosco.manifests;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.rosco.services.ClouddriverService;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,7 +27,13 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
 
   public InputStream downloadArtifact(Artifact artifact) throws IOException {
     Response response =
-        retrySupport.retry(() -> clouddriverService.fetchArtifact(artifact), 5, 1000, true);
+        retrySupport.retry(
+            () ->
+                AuthenticatedRequest.allowAnonymous(
+                    () -> clouddriverService.fetchArtifact(artifact)),
+            5,
+            1000,
+            true);
     if (response.getBody() == null) {
       throw new IOException("Failure to fetch artifact: empty response");
     }


### PR DESCRIPTION
to clean up warnings like
```
---> HTTP PUT http://spin-clouddriver-ro.spinnaker-stage:7002/artifacts/fetch/
2020-11-20 22:03:03.649  WARN 1 --- [0.0-8087-exec-1] c.n.s.okhttp.OkHttp3MetricsInterceptor   : Request PUT:http://spin-clouddriver-ro.spinnaker:7002/artifacts/fetch/ is missing [X-SPINNAKER-USER, X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous.
Request from: com.netflix.spinnaker.okhttp.MetricsInterceptor.doIntercept(MetricsInterceptor.java:98)
	at com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor.intercept(OkHttp3MetricsInterceptor.java:36)
	at com.netflix.spinnaker.rosco.manifests.ArtifactDownloaderImpl.lambda$downloadArtifact$0(ArtifactDownloaderImpl.java:29)
	at com.netflix.spinnaker.kork.core.RetrySupport.retry(RetrySupport.java:34)
	at com.netflix.spinnaker.kork.core.RetrySupport.retry(RetrySupport.java:27)
	at com.netflix.spinnaker.rosco.manifests.ArtifactDownloaderImpl.downloadArtifact(ArtifactDownloaderImpl.java:29)
	at com.netflix.spinnaker.rosco.manifests.BakeManifestEnvironment.downloadArtifactTarballAndExtract(BakeManifestEnvironment.java:74)
	at com.netflix.spinnaker.rosco.manifests.helm.HelmTemplateUtils.buildBakeRecipe(HelmTemplateUtils.java:52)
	at com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestService.bake(HelmBakeManifestService.java:38)
	at com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestService.bake(HelmBakeManifestService.java:15)
	at com.netflix.spinnaker.rosco.controllers.V2BakeryController.doBake(V2BakeryController.java:44)
	at com.netflix.spinnaker.rosco.filters.SimpleCORSFilter.doFilter(SimpleCORSFilter.groovy:34)
	at com.netflix.spinnaker.filters.AuthenticatedRequestFilter.doFilter(AuthenticatedRequestFilter.groovy:147)
```