### PR TITLE
feat(exceptions): improve error handling

### DIFF
--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -8,6 +8,7 @@ dependencies {
 
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spinnaker.kork:kork-jedis"
+  implementation "com.netflix.spinnaker.kork:kork-retrofit"
   implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:converter-jackson"

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ServiceConfig.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/services/ServiceConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,6 +59,7 @@ public class ServiceConfig {
         .setClient(ok3Client)
         .setConverter(new JacksonConverter(objectMapper))
         .setLogLevel(RestAdapter.LogLevel.valueOf(retrofitLogLevel))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .build()
         .create(ClouddriverService.class);
   }


### PR DESCRIPTION
by using the SpinnakerRetrofitErrorHandler class from kork, exceptions when rosco calls
other spinnaker microservices are more visible to the user

So, instead of seeing, for example

500

deck now shows

Status: 500, URL: http://spin-clouddriver-ro.spinnaker:7002/artifacts/fetch/, Message: Artifact credentials 'helm-account' cannot handle artifacts of type 'git/repo'

Visually, before:
![image](https://user-images.githubusercontent.com/1521148/101226742-4fd87e00-364a-11eb-8625-67206e22fae6.png)
after:
![image](https://user-images.githubusercontent.com/1521148/101226760-5c5cd680-364a-11eb-9f67-4cdf41941e76.png)

related to https://github.com/spinnaker/spinnaker/issues/5473