### PR TITLE
fix(rosco): Update Hashicorp Packer version in rosco to 1.6.6

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -4,9 +4,9 @@ LABEL maintainer="sig-platform@spinnaker.io"
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre git openssh-client && \
-  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
-  unzip packer_1.4.5_linux_amd64.zip && \
-  rm packer_1.4.5_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.6.6/packer_1.6.6_linux_amd64.zip && \
+  unzip packer_1.6.6_linux_amd64.zip && \
+  rm packer_1.6.6_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -4,9 +4,9 @@ LABEL maintainer="sig-platform@spinnaker.io"
 WORKDIR /packer
 
 RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl git openssh-client && \
-  wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
-  unzip packer_1.4.5_linux_amd64.zip && \
-  rm packer_1.4.5_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/1.6.6/packer_1.6.6_linux_amd64.zip && \
+  unzip packer_1.6.6_linux_amd64.zip && \
+  rm packer_1.6.6_linux_amd64.zip
 
 ENV PATH "/packer:$PATH"
 

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -12,7 +12,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 install_packer() {
-  PACKER_VERSION="1.4.5"
+  PACKER_VERSION="1.6.6"
   local packer_version=$(/usr/bin/packer --version)
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then


### PR DESCRIPTION
Using version 1.6.6 to resolve https://github.com/spinnaker/spinnaker/issues/6311 as well as get latest features of packer

