### PR TITLE
fix(helm): Guard against NullPointerException on missing overrides field

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -103,7 +103,7 @@ public class HelmTemplateUtils {
     }
 
     Map<String, Object> overrides = request.getOverrides();
-    if (!overrides.isEmpty()) {
+    if (overrides != null && !overrides.isEmpty()) {
       List<String> overrideList = new ArrayList<>();
       for (Map.Entry<String, Object> entry : overrides.entrySet()) {
         overrideList.add(entry.getKey() + "=" + entry.getValue().toString());


### PR DESCRIPTION
Submitting a pipeline with a `bakeManifest` stage that doesn't include the `overrides` field results in a `NullPointerException`.

Here is the stacktrace after submitting and executing a pipeline (through the API) without the `overrides` field. The deployed rosco version is `0.21.1`.

```
java.lang.NullPointerException: null
        at com.netflix.spinnaker.rosco.manifests.helm.HelmTemplateUtils.buildBakeRecipe(HelmTemplateUtils.java:83) ~[rosco-manifests.jar:na]
        at com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestService.bake(HelmBakeManifestService.java:38) ~[rosco-manifests.jar:na]
        at com.netflix.spinnaker.rosco.manifests.helm.HelmBakeManifestService.bake(HelmBakeManifestService.java:15) ~[rosco-manifests.jar:na]
        at com.netflix.spinnaker.rosco.controllers.V2BakeryController.doBake(V2BakeryController.java:44) ~[rosco-web.jar:na]
        at jdk.internal.reflect.GeneratedMethodAccessor189.invoke(Unknown Source) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190) ~[spring-web-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138) ~[spring-web-5.2.4.RELEASE.jar:5.2.4.RELEASE]
```