### PR TITLE
chore(build): hardcode helm v2 version to final release

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -23,7 +23,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-he
 # Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
-  ./get && \
+  ./get --version v2.17.0 && \
   rm get
 
 RUN mkdir kustomize && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -23,7 +23,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-he
 # Install Helm 2
 RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x get && \
-  ./get && \
+  ./get --version v2.17.0 && \
   rm get
 
 RUN mkdir kustomize && \


### PR DESCRIPTION
Helm V2 is EOL and install scripts are broken, see https://github.com/helm/helm/pull/9623 
I'm hardcoding the version to the latest helm v2 release. 