### PR TITLE
chore(bake): add base ami to completed bake details

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Bake.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/Bake.groovy
@@ -41,4 +41,7 @@ class Bake {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   List<Artifact> artifacts
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String base_ami
 }


### PR DESCRIPTION
This allows the Bake class to include the base AMI for use with managed delivery, related to https://github.com/spinnaker/orca/pull/4071.