### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2.13

### DIFF
--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/util/TestDefaults.groovy
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.api.BakeRequest.CloudProviderType
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe
+import spock.lang.Shared
 
 trait TestDefaults {
 
@@ -29,8 +30,11 @@ trait TestDefaults {
   static final String SOME_CLOUD_PROVIDER = "aws"
   static final String SOME_REGION = "eu-west-1"
 
+  @Shared
   final Bake SOME_BAKE_DETAILS = new Bake(id: SOME_JOB_ID, ami: SOME_AMI_ID, image_name: SOME_IMAGE_NAME)
+  @Shared
   final BakeRequest SOME_BAKE_REQUEST = new BakeRequest(build_info_url: SOME_BUILD_INFO_URL, build_number: SOME_BUILD_NR)
+  @Shared
   final BakeRecipe SOME_BAKE_RECIPE = new BakeRecipe(name: SOME_BAKE_RECIPE_NAME, version: SOME_APP_VERSION_STR, command: [])
 
   static final BakeRequest.PackageType DEB_PACKAGE_TYPE = BakeRequest.PackageType.DEB


### PR DESCRIPTION
Refer spinnaker/spinnaker#6537

During verification of spring boot upgrade using spinnaker/kork#895, received below error:
```
Task :rosco-core:compileTestGroovy
startup failed:
/rosco/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy: 69: Only @Shared and static fields may be accessed from here @ line 69, column 7.
         SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | SOME_BUILD_INFO_URL | SOME_BUILD_NR
         ^

/rosco/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy: 68: Only @Shared and static fields may be accessed from here @ line 68, column 27.
         null              | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | null                | null
                             ^

/rosco/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy: 69: Only @Shared and static fields may be accessed from here @ line 69, column 27.
         SOME_BAKE_REQUEST | SOME_BAKE_RECIPE | SOME_BAKE_RECIPE_NAME | null                 | SOME_AMI_ID       | SOME_BUILD_INFO_URL | SOME_BUILD_NR
         ^
```
This PR fix the error while executing the test cases spring boot upgrade.