### PR TITLE
Improve clouddriver exception handling

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.rosco.manifests;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.rosco.services.ClouddriverService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.IOException;
@@ -12,7 +13,6 @@ import java.nio.file.Path;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 @Component
@@ -51,8 +51,8 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
                 artifact, e.getMessage()),
             e);
       }
-    } catch (RetrofitError e) {
-      throw new IOException(
+    } catch (SpinnakerException e) {
+      throw new SpinnakerException(
           String.format("Failed to download artifact: %s. Error: %s", artifact, e.getMessage()), e);
     }
   }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.rosco.manifests.helm;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader;
 import com.netflix.spinnaker.rosco.manifests.BakeManifestEnvironment;
@@ -62,7 +63,7 @@ public class HelmTemplateUtils {
     } else {
       try {
         templatePath = downloadArtifactToTmpFile(env, helmTemplateArtifact);
-      } catch (IOException e) {
+      } catch (IOException | SpinnakerException e) {
         throw new IllegalStateException("Failed to fetch helm template: " + e.getMessage(), e);
       }
     }
@@ -74,7 +75,7 @@ public class HelmTemplateUtils {
       for (Artifact valueArtifact : inputArtifacts.subList(1, inputArtifacts.size())) {
         valuePaths.add(downloadArtifactToTmpFile(env, valueArtifact));
       }
-    } catch (IOException e) {
+    } catch (IOException | SpinnakerException e) {
       throw new IllegalStateException("Failed to fetch helm values file: " + e.getMessage(), e);
     }
 

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
@@ -83,11 +83,10 @@ final class ArtifactDownloaderImplTest {
               SpinnakerException.class,
               () -> artifactDownloader.downloadArtifactToFile(testArtifact, file.path));
 
-      // FIXME: this is the current behavior, but it's unfortunate that we're
-      // not currently wrapping the exception from clouddriver with our own info
-      // (e.g. the artifact)
-      assertThat(thrown.getMessage()).contains("error from clouddriver");
-      assertThat(thrown.getCause()).isNull();
+      // Make sure we have the message we expect, and that we wrapped the
+      // underlying exception to not lose any info.
+      assertThat(thrown.getMessage()).contains("Failed to download artifact");
+      assertThat(thrown.getCause()).isEqualTo(spinnakerException);
     }
   }
 

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
@@ -16,16 +16,18 @@
 
 package com.netflix.spinnaker.rosco.manifests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.rosco.services.ClouddriverService;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -36,7 +38,7 @@ import retrofit.mime.TypedByteArray;
 
 @RunWith(JUnitPlatform.class)
 final class ArtifactDownloaderImplTest {
-  private static final ClouddriverService clouddriverService = mock(ClouddriverService.class);
+  private final ClouddriverService clouddriverService = mock(ClouddriverService.class);
   private static final Artifact testArtifact =
       Artifact.builder().name("test-artifact").version("3").build();
 
@@ -50,7 +52,7 @@ final class ArtifactDownloaderImplTest {
           .thenReturn(successfulResponse(testContent));
       artifactDownloader.downloadArtifactToFile(testArtifact, file.path);
 
-      Assertions.assertThat(file.path).hasContent(testContent);
+      assertThat(file.path).hasContent(testContent);
     }
   }
 
@@ -65,7 +67,27 @@ final class ArtifactDownloaderImplTest {
           .thenReturn(successfulResponse(testContent));
       artifactDownloader.downloadArtifactToFile(testArtifact, file.path);
 
-      Assertions.assertThat(file.path).hasContent(testContent);
+      assertThat(file.path).hasContent(testContent);
+    }
+  }
+
+  @Test
+  public void exceptionDownloadingArtifactContent() throws IOException {
+    ArtifactDownloaderImpl artifactDownloader = new ArtifactDownloaderImpl(clouddriverService);
+    SpinnakerException spinnakerException = new SpinnakerException("error from clouddriver");
+    try (ArtifactDownloaderImplTest.AutoDeletingFile file = new AutoDeletingFile()) {
+      when(clouddriverService.fetchArtifact(testArtifact)).thenThrow(spinnakerException);
+
+      SpinnakerException thrown =
+          assertThrows(
+              SpinnakerException.class,
+              () -> artifactDownloader.downloadArtifactToFile(testArtifact, file.path));
+
+      // FIXME: this is the current behavior, but it's unfortunate that we're
+      // not currently wrapping the exception from clouddriver with our own info
+      // (e.g. the artifact)
+      assertThat(thrown.getMessage()).contains("error from clouddriver");
+      assertThat(thrown.getCause()).isNull();
     }
   }
 

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -16,8 +16,12 @@
 
 package com.netflix.spinnaker.rosco.manifests.helm;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +29,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader;
 import com.netflix.spinnaker.rosco.manifests.BakeManifestEnvironment;
@@ -70,6 +75,39 @@ final class HelmTemplateUtilsTest {
 
     try (BakeManifestEnvironment env = BakeManifestEnvironment.create()) {
       BakeRecipe recipe = helmTemplateUtils.buildBakeRecipe(env, bakeManifestRequest);
+    }
+  }
+
+  public void exceptionDownloading() throws IOException {
+    // When artifactDownloader throws an exception, make sure we wrap it and get
+    // a chance to include our own message, so the exception that goes up the
+    // chain includes something about helm charts.
+    SpinnakerException spinnakerException = new SpinnakerException("error from ArtifactDownloader");
+    ArtifactDownloader artifactDownloader = mock(ArtifactDownloader.class);
+    doThrow(spinnakerException)
+        .when(artifactDownloader)
+        .downloadArtifactToFile(any(Artifact.class), any(Path.class));
+
+    RoscoHelmConfigurationProperties helmConfigurationProperties =
+        mock(RoscoHelmConfigurationProperties.class);
+    HelmTemplateUtils helmTemplateUtils =
+        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+    Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
+
+    HelmBakeManifestRequest bakeManifestRequest = new HelmBakeManifestRequest();
+    bakeManifestRequest.setInputArtifacts(ImmutableList.of(chartArtifact));
+
+    try (BakeManifestEnvironment env = BakeManifestEnvironment.create()) {
+      // FIXME: unfortunately we're not wrapping the exception from
+      // ArtifactDownloader, so we lose our chance to add a helm-specific
+      // message.
+      SpinnakerException thrown =
+          assertThrows(
+              SpinnakerException.class,
+              () -> helmTemplateUtils.buildBakeRecipe(env, bakeManifestRequest));
+
+      assertThat(thrown).isEqualTo(spinnakerException);
+      assertThat(thrown.getCause()).isNull();
     }
   }
 

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -98,16 +98,13 @@ final class HelmTemplateUtilsTest {
     bakeManifestRequest.setInputArtifacts(ImmutableList.of(chartArtifact));
 
     try (BakeManifestEnvironment env = BakeManifestEnvironment.create()) {
-      // FIXME: unfortunately we're not wrapping the exception from
-      // ArtifactDownloader, so we lose our chance to add a helm-specific
-      // message.
-      SpinnakerException thrown =
+      IllegalStateException thrown =
           assertThrows(
-              SpinnakerException.class,
+              IllegalStateException.class,
               () -> helmTemplateUtils.buildBakeRecipe(env, bakeManifestRequest));
 
-      assertThat(thrown).isEqualTo(spinnakerException);
-      assertThat(thrown.getCause()).isNull();
+      assertThat(thrown.getMessage()).contains("Failed to fetch helm template");
+      assertThat(thrown.getCause()).isEqualTo(spinnakerException);
     }
   }
 


### PR DESCRIPTION
These changes should really have been in https://github.com/spinnaker/rosco/pull/750.  That PR added detail from clouddriver, but at the expense of detail from rosco about the artifact and messages about helm charts and downloading.  This restores the info from before that PR.

![image](https://user-images.githubusercontent.com/82477955/139508001-d91cd7cc-e58b-4aec-aff9-5e18b20aa91c.png)

where before this PR that was:

![image](https://user-images.githubusercontent.com/82477955/139508102-8641eb5a-9c4f-4a61-b938-df7e9046e611.png)
