### PR TITLE
feat(publishing): artifact registry publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
           ./gradlew --info publishToNexus closeAndReleaseNexusStagingRepository
+      - name: Publish apt and rpm packages to Google Artifact Registry
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
+          ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
+          ORG_GRADLE_PROJECT_artifactRegistryPublishAptEnabled: true
+          GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
+        run: |
+          ./gradlew --info publish
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
           ./gradlew --info publishToNexus closeAndReleaseNexusStagingRepository
-      - name: Publish apt and rpm packages to Google Artifact Registry
+      - name: Publish apt packages to Google Artifact Registry
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'io.spinnaker.package'
+apply plugin: 'io.spinnaker.artifactregistry-publish'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())


### PR DESCRIPTION
Incorporates the new io.spinnaker.artifactregistry-publish plugin to rosco-web. This will publish the apt and rpm packages for rosco to the Google Artifact Registry


