### PR TITLE
chore(ci): GHA - container image build & push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
           file: Dockerfile.slim
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-slim"
       - name: Build and publish ubuntu container image
         uses: docker/build-push-action@v2
         with:
@@ -48,5 +48,5 @@ jobs:
           file: Dockerfile.ubuntu
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-ubuntu"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
         run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
       - name: Build
         run: ./gradlew build --stacktrace ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+      - name: Get date
+        id: get_date
+        run: echo ::set-output name=DATETIME::$(date --utc +'%Y%m%d%H%M')
       - name: Build and publish slim container image
         uses: docker/build-push-action@v2
         with:
@@ -35,7 +38,9 @@ jobs:
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated-slim"
       - name: Build and publish ubuntu container image
         uses: docker/build-push-action@v2
         with:
@@ -44,3 +49,4 @@ jobs:
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-unvalidated-ubuntu"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:
   branch-build:
@@ -21,5 +22,25 @@ jobs:
           java-version: 11
           distribution: 'zulu'
           cache: 'gradle'
+      - name: Extract repository name
+        id: extract_repo_name
+        run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
       - name: Build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build --stacktrace ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+      - name: Build and publish slim container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.slim
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
+      - name: Build and publish ubuntu container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-    - version-*
+    - release-*
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on: [ pull_request ]
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:
   build:
@@ -15,5 +16,25 @@ jobs:
         java-version: 11
         distribution: 'zulu'
         cache: 'gradle'
+    - name: Extract repository name
+      id: extract_repo_name
+      run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
     - name: Build
-      run: ./gradlew build
+      run: "./gradlew build ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+    - name: Build slim container image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile.slim
+        tags: |
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-slim"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-slim"
+    - name: Build ubuntu container image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile.ubuntu
+        tags: |
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-ubuntu"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-ubuntu"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,9 @@ jobs:
       run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
     - name: Build
       run: "./gradlew build ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+    - name: Get date
+      id: get_date
+      run: echo ::set-output name=DATETIME::$(date --utc +'%Y%m%d%H%M')
     - name: Build slim container image
       uses: docker/build-push-action@v2
       with:
@@ -28,8 +31,9 @@ jobs:
         file: Dockerfile.slim
         tags: |
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest"
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-slim"
-          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-slim"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-slim"
     - name: Build ubuntu container image
       uses: docker/build-push-action@v2
       with:
@@ -37,4 +41,4 @@ jobs:
         file: Dockerfile.ubuntu
         tags: |
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-ubuntu"
-          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-ubuntu"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-ubuntu"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,9 +31,9 @@ jobs:
         file: Dockerfile.slim
         tags: |
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest"
-          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}"
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-slim"
-          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-slim"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-slim"
     - name: Build ubuntu container image
       uses: docker/build-push-action@v2
       with:
@@ -41,4 +41,4 @@ jobs:
         file: Dockerfile.ubuntu
         tags: |
           "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-ubuntu"
-          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-latest-ubuntu"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-ubuntu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,9 @@ jobs:
           file: Dockerfile.slim
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-slim"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-unvalidated-slim"
       - name: Build and publish ubuntu container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
@@ -83,8 +83,8 @@ jobs:
           file: Dockerfile.ubuntu
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-ubuntu"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-unvalidated-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:
   release:
@@ -30,6 +31,9 @@ jobs:
           echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
           echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
           echo ::set-output name=RELEASE_VERSION::${RELEASE_VERSION}
+      - name: Extract repository name
+        id: extract_repo_name
+        run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
       - name: Release build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
@@ -39,7 +43,7 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
-          ./gradlew --info publishToNexus closeAndReleaseNexusStagingRepository
+          ./gradlew --info build ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
       - name: Publish apt packages to Google Artifact Registry
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
@@ -47,6 +51,35 @@ jobs:
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publish
+      - name: Login to GAR
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/login-action@v1
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+      - name: Build and publish slim container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.slim
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-slim"
+      - name: Build and publish ubuntu container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publish
+      - name: Get date
+        id: get_date
+        run: echo ::set-output name=DATETIME::$(date --utc +'%Y%m%d%H%M')
       - name: Login to GAR
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
@@ -70,6 +73,7 @@ jobs:
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-slim"
       - name: Build and publish ubuntu container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
@@ -80,6 +84,7 @@ jobs:
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-$${{ github.sha }}-{{ steps.get_date.outputs.DATETIME }}-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1


### PR DESCRIPTION
shared:
- GHA doesn't have a repository name env var like `clouddriver` so
  add a step to extract the name from `spinnaker/clouddriver`
- Change build step to create installation distribution for use in
  following container image build steps.
- add Alpine/slim container build step
- add Ubuntu container build step

when open PR has commit pushed to fork's branch:
- build only and don't push
   - `latest{-slim|ubuntu}`
   - `{git-SHA}-{DATE-TIME}{-slim|ubuntu}`
- validates gradle build, unit tests pass and Dockerfile's build

when commit pushed to specific branches (eg: merge PR):
- build and push with branch tags:
  - `master` -> `master-latest-unvalidated-{slim|ubuntu}`
  - `master` -> `master-{git-SHA}-{DATE-TIME}-unvalidated-{slim|ubuntu}`
  - `release-*` -> `{release-*}-latest-unvalidated-{slim-ubuntu}`
  - `release-*` -> `{release-*}-{git-SHA}-{DATE-TIME}-unvalidated-{slim-ubuntu}`
- DONE: change `version-*` to `release-*` to do action on merge to release
  branches.

when push tag x.y.z (i.e: Release):
- build and push with version tag.
  - `RELEASE_VERSION` -> `{RELEASE_VERSION}-unvalidated-{slim-ubuntu}`
  - `RELEASE_VERSION*` -> `{RELEASE_VERSION}-{git-SHA}-{DATE-TIME}-unvalidated-{slim-ubuntu}`
- DONE: clarify if this is still necessary or should be revised to be
  inline with `release-x.y.z` - follow same pattern as Debian packages.

DONE: confirmed we need/want {date} in image tag name per previous CI. - Identifies distinct builds created by non-idempotent actions.