### PR TITLE
chore(publishing): clean up from debugging artifact registry publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,9 @@ jobs:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
           ORG_GRADLE_PROJECT_artifactRegistryPublishMavenEnabled: false
-          ORG_GRADLE_PROJECT_artifactRegistryPublishAptEnabled: true
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          ./gradlew --info --stacktrace rosco-web:publish
+          ./gradlew --info publish
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'io.spinnaker.package'
-apply plugin: 'io.spinnaker.artifactregistry-publish'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())


### PR DESCRIPTION
- there's no need to apply io.spinnaker.artifactregistry-publish in rosco-web.gradle.  The
  [spinnaker project plugin does that for us](https://github.com/spinnaker/spinnaker-gradle-project/blob/49d277f619d9a79c75be91c358ea38658c84de7f/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy#L34).

- apt publishing is enabled by default, so no need to specify `ORG_GRADLE_PROJECT_artifactRegistryPublishAptEnabled: true` in release.yml

- the logic in [ArtifactRegistryPublishPlugin](https://github.com/spinnaker/spinnaker-gradle-project/blob/49d277f619d9a79c75be91c358ea38658c84de7f/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishPlugin.groovy#L50) publishes debian packages from all projects that build them, so there's no need to invoke the publish task only on rosco-web.
