### PR TITLE
chore(publishing): remove ORG_GRADLE_PROJECT_artifactRegistryPublishM…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
-          ORG_GRADLE_PROJECT_artifactRegistryPublishMavenEnabled: false
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publish


### PR DESCRIPTION
…avenEnabled: false

from release.yml now that it defaults to false.  See
https://github.com/spinnaker/spinnaker-gradle-project/pull/179.
