### PR TITLE
fix(image): Add tzdata to set timezone on rosco pod

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -6,7 +6,7 @@ ENV PACKER_VERSION=1.6.6
 
 WORKDIR /packer
 
-RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre git openssh-client && \
+RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre git openssh-client tzdata && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -6,7 +6,7 @@ ENV PACKER_VERSION=1.6.6
 
 WORKDIR /packer
 
-RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl git openssh-client && \
+RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl git openssh-client tzdata && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Issue:
Inorder to set timezone on a container, setting it through "TZ" environment variable is one of the ways. However, as tzdata package is not installed on the pod, setting "TZ" environment variable doesn't make any difference.

Solution:
Having "tzdata" package installed on the pod gives the flexibility to the user to simply set "TZ" env var and configurable timezone of the pod for better troubleshooting of the logs.