### PR TITLE
fix(ci): GHA - use correct env var from context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
           file: Dockerfile.slim
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-slim"
       - name: Build and publish ubuntu container image
         uses: docker/build-push-action@v2
         with:
@@ -48,5 +48,5 @@ jobs:
           file: Dockerfile.ubuntu
           push: true
           tags: |
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"
-            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ env.GITHUB_REF_NAME }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.ref_name }}-${{ github.sha }}-${{ steps.get_date.outputs.DATETIME }}-unvalidated-ubuntu"


### PR DESCRIPTION
https://github.com/kskewes/rosco/runs/5491186233?check_suite_focus=true#step:7:1

This fixes putting branch name, eg: `master` into the container tag - `us-docker.pkg.dev/spinnaker-community/docker/rosco:master-latest-unvalidated`
GHA output from merging this PR to my fork (with spinnaker org only and push disabled).

```
Run docker/build-push-action@v2
Docker info
/usr/bin/docker buildx build --file Dockerfile.slim --iidfile /tmp/docker-build-push-TbWVCS/iidfile --tag us-docker.pkg.dev/spinnaker-community/docker/rosco:master-latest-unvalidated --tag us-docker.pkg.dev/spinnaker-community/docker/rosco:master-740ddea487ee3bc0ae5d9b9bbe7e16c5d5d40569-202203100526-unvalidated --tag us-docker.pkg.dev/spinnaker-community/docker/rosco:master-latest-unvalidated-slim --tag us-docker.pkg.dev/spinnaker-community/docker/rosco:master-740ddea487ee3bc0ae5d9b9bbe7e16c5d5d40569-202203100526-unvalidated-slim --metadata-file /tmp/docker-build-push-TbWVCS/metadata-file .
```