### PR TITLE
chore(ci): Upload halconfigs to GCS on Tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,29 @@ jobs:
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publish
+      - name: Tar Packer templates for upload to GCS
+        # Note, Halyard expects packer.tar.gz but doesn't actually gunzip it.
+        # Thus we must create a non-gzipped tar archive.
+        run: |
+          cd halconfig/packer
+          tar -cf ../packer.tar.gz *
+      - name: Login to Google Cloud
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/auth@v0'
+        # use service account flow defined at: https://github.com/google-github-actions/upload-cloud-storage#authenticating-via-service-account-key-json
+        with:
+          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+      - name: Upload halconfig profiles to GCS
+        # https://console.cloud.google.com/storage/browser/halconfig
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/upload-cloud-storage@v0'
+        with:
+          path: 'halconfig/'
+          glob: '*'  # exclude directories as we tar.gz it first above
+          destination: 'halconfig/${{ steps.build_variables.outputs.REPO }}/${{ steps.release_info.outputs.RELEASE_VERSION }}'
+          parent: false
       - name: Login to GAR
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')


### PR DESCRIPTION
A combination of https://github.com/spinnaker/rosco/pull/869 and
https://github.com/spinnaker/rosco/pull/870, combined manually.

Previous release tools would publish basic halconfig profiles to GCS
bucket: https://console.cloud.google.com/storage/browser/halconfig/`<service>`/`<version>`/*

Where `<service>` might be `rosco` and `<version>` is our git tag, eg: `v1.2.3`.

Halyard downloads these profiles during `hal deploy apply`.
As the profiles are deprecated it would be ideal to remove from Halyard
but it may break users workflows.

For now we can upload the files as part of our regular service 'release'
flow (git tag <version> && git push) using GHA.
