### PR TITLE
fix(halyard): Use Halyard's spinnaker.yml defined Redis

### DIFF
--- a/halconfig/rosco.yml
+++ b/halconfig/rosco.yml
@@ -1,5 +1,11 @@
 # halconfig
 
+# Rosco doesn't seem to pick up this configuration from /opt/rosco/rosco.yml
+# and doesn't use the default Halyard redis deployment like gate and others.
+# Instead Rosco tries and fails to connect to redis at redis://localhost:6379.
+redis:
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
+
 server:
   port: ${services.rosco.port:8087}
   address: ${services.rosco.host:localhost}


### PR DESCRIPTION
Otherwise Rosco tries and fails to connect to code fallback of
redis://localhost:6379

Tested in Halyard with a custom BOM and halconfigs.

```
2022-04-26 00:32:12.895 ERROR 1 --- [RxIoScheduler-2] c.n.spinnaker.rosco.executor.BakePoller  : Update Polling Error:

redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from the pool
 
<snip>
Caused by: redis.clients.jedis.exceptions.JedisConnectionException: Failed connecting to host localhost:6379
```