### PR TITLE
Arm64 support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contr
 
 When filling out a pull request, please consider the following:
 
-* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
+* Follow the commit message conventions [found here](https://spinnaker.io/docs/community/contributing/code/submitting/).
 * Provide a descriptive summary for your changes.
 * If it fixes a bug or resolves a feature request, be sure to link to that issue.
 * Add inline code comments to changes that might not be obvious.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - uses: actions/setup-java@v2
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -45,10 +50,11 @@ jobs:
       - name: Build and publish slim container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.slim
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated"
@@ -58,10 +64,11 @@ jobs:
       - name: Build and publish ubuntu container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.ubuntu
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated-ubuntu"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -28,9 +32,10 @@ jobs:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
         run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist
       - name: Build slim container image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile.slim
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest"
@@ -38,9 +43,10 @@ jobs:
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-slim"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-slim"
       - name: Build ubuntu container image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile.ubuntu
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-ubuntu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
           java-version: 11
           distribution: 'zulu'
           cache: 'gradle'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - uses: actions/setup-java@v2
       - name: Assemble release info
         id: release_info
         env:
@@ -89,10 +94,11 @@ jobs:
       - name: Build and publish slim container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.slim
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated"
@@ -101,10 +107,11 @@ jobs:
       - name: Build and publish ubuntu container image
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.ubuntu
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated-ubuntu"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,15 +1,19 @@
 FROM alpine:3.12
 LABEL maintainer="sig-platform@spinnaker.io"
 
-ENV KUSTOMIZE_VERSION=3.8.5
+ENV KUSTOMIZE_VERSION=3.8.6
 ENV PACKER_VERSION=1.6.6
+
+
+ARG TARGETARCH
+
 
 WORKDIR /packer
 
 RUN apk --no-cache add --update bash wget curl openssl openjdk11-jre git openssh-client && \
-  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
-  unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
-  rm packer_${PACKER_VERSION}_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip
 
 ENV PATH "/packer:$PATH"
 
@@ -27,7 +31,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   rm get
 
 RUN mkdir kustomize && \
-  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz|\
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz|\
   tar xvz -C kustomize/
 
 ENV PATH "kustomize:$PATH"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,15 +1,17 @@
 FROM ubuntu:bionic
 LABEL maintainer="sig-platform@spinnaker.io"
 
-ENV KUSTOMIZE_VERSION=3.8.5
+ENV KUSTOMIZE_VERSION=3.8.6
 ENV PACKER_VERSION=1.6.6
+
+ARG TARGETARCH
 
 WORKDIR /packer
 
 RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget unzip curl git openssh-client && \
-  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
-  unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
-  rm packer_${PACKER_VERSION}_linux_amd64.zip
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip
 
 ENV PATH "/packer:$PATH"
 
@@ -27,7 +29,7 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
   rm get
 
 RUN mkdir kustomize && \
-  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz|\
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz|\
   tar xvz -C kustomize/
 
 ENV PATH "kustomize:$PATH"


### PR DESCRIPTION
Changes that allow building Rosco images for both amd64 and arm64 architectures.  That's the first of many PRs to various Spinnaker Components that allow building docker images for multiple architectures.

Motivation:
Allow running & experimenting with Spinnaker locally on Macbok M1.

Changes:
- Choose binaries in docker build based on the target architecture
- bump Kustomize to a version that contains arm64 binaries
- update Github action to build multiple architectures


