### PR TITLE
chore(builds): fix github actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v2
-      - uses: actions/setup-java@v2
         with:
           java-version: 11
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - uses: actions/setup-java@v2
       - name: Assemble release info
         id: release_info
         env:


### PR DESCRIPTION
A follow-up to https://github.com/spinnaker/rosco/pull/886 that fixes Github actions builds

Remove duplicate setup-java actions without proper config
