### PR TITLE
chore(dependencies): use org.apache.commons:commons-compress:1.21 to …

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.spinnaker.kork:kork-security"
   implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.14"
+  implementation "org.apache.commons:commons-compress:1.21"
   implementation "org.yaml:snakeyaml:1.25"
 
   implementation "com.squareup.retrofit:retrofit"


### PR DESCRIPTION
…fix multiple vulnerabilities

CVE-2018-11771
CVE-2021-36090
CVE-2021-35515
CVE-2021-35516
CVE-2021-35517
CVE-2021-36090
sonatype-2018-0293
