### PR TITLE
chore(dockerfile): upgrade to latest alpine image

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 RUN apk add --update \
     openjdk11 \
     && rm -rf /var/cache/apk

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUSTOMIZE_VERSION=3.8.6


### PR DESCRIPTION
This resolves a performance issue in JDK11 when Spinnaker is running in
a cluster with containerd.