### PR TITLE
feat(azure): Improve uniqueness of Azure Bake Key

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandler.groovy
@@ -56,7 +56,22 @@ public class AzureBakeHandler extends CloudProviderBakeHandler{
 
   @Override
   String produceProviderSpecificBakeKeyComponent(String region, BakeRequest bakeRequest) {
-    return resolveAccount(bakeRequest).name
+    String accountName = resolveAccount(bakeRequest).name
+
+    String selectedImage = null
+    if (bakeRequest.publisher) {
+      selectedImage = bakeRequest.publisher + ":" + bakeRequest.offer + ":" + bakeRequest.sku
+    }
+    if (bakeRequest.custom_managed_image_name) {
+      selectedImage = bakeRequest.custom_managed_image_name
+    }
+
+    String base_label = bakeRequest.base_label
+    String base_name = bakeRequest.base_name
+
+    def keys = [accountName, selectedImage, base_label, base_name].stream().findAll()
+
+    return keys.join(":")
   }
 
   @Override


### PR DESCRIPTION
By adding these fields to the bake key, it will enable concurrent bakes when selecting a different image, base label or base name. 

Resolves https://github.com/spinnaker/spinnaker/issues/6738