### PR TITLE
feat(helm): support for including crds in Helm3

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestRequest.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmBakeManifestRequest.java
@@ -20,6 +20,13 @@ public class HelmBakeManifestRequest extends BakeManifestRequest {
   boolean rawOverrides;
 
   /**
+   * Helm v3 adds a new flag to include custom resource definition manifests in the templated
+   * output. In the previous versions crds were usually included as part templates, so the `helm
+   * template` command always included them in the rendered output.
+   */
+  boolean includeCRDs;
+
+  /**
    * When the helm chart is (in) a git/repo artifact, the path to the chart.
    *
    * <p>null/unspecified means the chart is in the root directory of the artifact.

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtils.java
@@ -108,6 +108,11 @@ public class HelmTemplateUtils {
       command.add(namespace);
     }
 
+    if (request.isIncludeCRDs()
+        && request.getTemplateRenderer() == BakeManifestRequest.TemplateRenderer.HELM3) {
+      command.add("--include-crds");
+    }
+
     Map<String, Object> overrides = request.getOverrides();
     if (!overrides.isEmpty()) {
       List<String> overrideList = new ArrayList<>();


### PR DESCRIPTION
This is part of https://github.com/spinnaker/spinnaker/issues/6518

Adds a new flag to include custom resource definition manifests in the templated output while selecting Helm 3 as template renderer.