### PR TITLE
fix(azure): removing empty params for image name

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/util/AzureImageNameFactory.java
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/azure/util/AzureImageNameFactory.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.rosco.providers.util.ImageNameFactory;
 import com.netflix.spinnaker.rosco.providers.util.PackageNameConverter;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 
 public class AzureImageNameFactory extends ImageNameFactory {
 
@@ -43,6 +44,8 @@ public class AzureImageNameFactory extends ImageNameFactory {
             ? bakeRequest.getBase_os()
             : bakeRequest.getOs_type().name();
 
-    return String.join("-", List.of(baseName, arch, release, os));
+    List<String> nameParams = new java.util.ArrayList<>(List.of(baseName, arch, release, os));
+    nameParams.removeIf(StringUtils::isBlank);
+    return String.join("-", nameParams);
   }
 }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/util/AzureImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/util/AzureImageNameFactorySpec.groovy
@@ -56,4 +56,22 @@ class AzureImageNameFactorySpec extends Specification implements TestDefaults {
         then:
         imageName == "7zip-all-release-linux"
     }
+
+    void "Should provide a valid image name when base_name and package_name are empty"() {
+        setup:
+        def imageNameFactory = new AzureImageNameFactory()
+        def bakeRequest = new BakeRequest(
+                package_name: "",
+                base_name: null,
+                base_label: BakeRequest.Label.unstable,
+                os_type: BakeRequest.OsType.windows
+        )
+        def osPackages = parseNupkgOsPackageNames(bakeRequest.package_name)
+
+        when:
+        def imageName = imageNameFactory.buildImageName(bakeRequest, osPackages)
+
+        then:
+        imageName == "all-unstable-windows"
+    }
 }


### PR DESCRIPTION
Previously for azure, it was using the class `ImageNameFactory`, that class is written in groovy and it was removing empty params
Fixes spinnaker/spinnaker#6753