### PR TITLE
chore(deps): remove version specification from org.yaml:snakeyaml

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -11,7 +11,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-security"
   implementation "commons-io:commons-io"
   implementation "org.apache.commons:commons-compress:1.21"
-  implementation "org.yaml:snakeyaml:1.25"
+  implementation "org.yaml:snakeyaml"
 
   implementation "com.squareup.retrofit:retrofit"
   testImplementation "org.assertj:assertj-core"


### PR DESCRIPTION
Spring boot 2.4.13 brings in version 1.27 of org.yaml:snakeyaml (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.4.13/spring-boot-dependencies-2.4.13.pom) which takes precendence over what we specified here (1.25), so there's no functional change.  See these snippets of ./gradlew rosco-manifests:dependencies before
```
+--- org.yaml:snakeyaml:1.25 -> 1.27
```
and after this change:
```
+--- org.yaml:snakeyaml -> 1.27
```
