### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -1,12 +1,5 @@
 apply plugin: 'io.spinnaker.package'
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-}
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-}
 mainClassName = 'com.netflix.spinnaker.rosco.Main'
 
 configurations.all {


### PR DESCRIPTION
The property spring.config.additional-location is redundant in rosco-web.gradle file. This property is set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.rosco.Main. So removing it from gradle file.

