### PR TITLE
chore(dependencies): remove dependency on groovy-all where straightforward

### DIFF
--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "io.reactivex:rxjava"
   implementation "org.apache.commons:commons-exec"
-  implementation "org.codehaus.groovy:groovy-all"
+  implementation "org.codehaus.groovy:groovy"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "redis.clients:jedis"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -15,6 +15,7 @@ dependencies {
 
   implementation "com.squareup.retrofit:retrofit"
   testImplementation "org.assertj:assertj-core"
+  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.swagger:swagger-annotations"
 
-  implementation "org.codehaus.groovy:groovy-all"
+  implementation "org.codehaus.groovy:groovy"
   implementation "io.spinnaker.kork:kork-artifacts"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "net.logstash.logback:logstash-logback-encoder"


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
