### PR TITLE
chore(web): clean up for spring property setup

### DIFF
--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -15,6 +15,7 @@ dependencies {
 
   implementation "org.codehaus.groovy:groovy"
   implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-config"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "net.logstash.logback:logstash-logback-encoder"
 

--- a/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
+++ b/rosco-web/src/main/groovy/com/netflix/spinnaker/rosco/Main.groovy
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.filter.ShallowEtagHeaderFilter
+import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder
 
 import javax.servlet.Filter
 
@@ -74,16 +75,7 @@ import javax.servlet.Filter
 @EnableScheduling
 class Main extends SpringBootServletInitializer {
 
-  static final Map<String, String> DEFAULT_PROPS = [
-    'netflix.environment': 'test',
-    'netflix.account': '${netflix.environment}',
-    'bakeAccount': '${netflix.account}',
-    'netflix.stack': 'test',
-    'spring.config.additional-location': '${user.home}/.spinnaker/',
-    'spring.application.name': 'rosco',
-    'spring.config.name': 'spinnaker,${spring.application.name}',
-    'spring.profiles.active': '${netflix.environment},local'
-  ]
+  static final Map<String, String> DEFAULT_PROPS = new DefaultPropertiesBuilder().property("spring.application.name", "rosco").property('bakeAccount','${netflix.account}').build()
 
   static void main(String... args) {
     new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)


### PR DESCRIPTION
Using `com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder` class to setup spring and other related properties required for the spring boot application to start.