### PR TITLE
chore(dependencies): remove residual dependency on groovy-all in rosco-manifest

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -15,7 +15,6 @@ dependencies {
 
   implementation "com.squareup.retrofit:retrofit"
   testImplementation "org.assertj:assertj-core"
-  testImplementation "org.codehaus.groovy:groovy-all"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"


### PR DESCRIPTION
Since groovy is introduced by rosco-core project in rosco-manifest.gradle, so removing the dependency.
```
$ ./gradlew rosco-manifest:dI --dependency groovy

> Task :rosco-manifests:dependencyInsight
org.codehaus.groovy:groovy:2.5.15
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes+resources)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 11
   ]
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:2.5.15
\--- io.spinnaker.kork:kork-bom:7.165.0
     \--- compileClasspath

org.codehaus.groovy:groovy -> 2.5.15
\--- project :rosco-core
     \--- compileClasspath
```
