### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 in rosco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,14 @@ subprojects {
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
       testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
     }
 
     test {
       testLogging {
         exceptionFormat = 'full'
       }
+      useJUnitPlatform()
     }
   }
 

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -22,7 +22,3 @@ dependencies {
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -28,10 +28,6 @@ dependencies {
   testImplementation "org.objenesis:objenesis"
 }
 
-test {
-  useJUnitPlatform()
-}
-
 ospackage {
   from('../halconfig/packer') {
     into '/opt/rosco/config/packer'


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from [spring-boot-starter-test](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test). It is required for executing junit4 based test cases in rosco. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 217 to 252 test case executions.