### PR TITLE
fix(manifests/test): add org.junit.jupiter:junit-jupiter-engine as a test runtime dependency

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -20,4 +20,5 @@ dependencies {
   testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -18,7 +18,6 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-runner"
-  testImplementation "org.junit.vintage:junit-vintage-engine"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
 }


### PR DESCRIPTION
so junit5 tests run.  Before this PR, 9 tests ran in rosco-manifests, all spock tests.  After this PR, 32 tests run.

Before:
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/82477955/226766644-5ba783a7-a97a-4eaf-97d5-08c9cbdfb0b5.png">

After:
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/82477955/226766673-a7582450-8af2-4a53-81b7-884ec492b79f.png">

Note that spring-boot-starter-test brings in org.junit.jupiter:junit-jupiter-engine so where that's used, we don't need to declare junit-jupiter-engine explicitly.  Note also that rosco-core currently only has spock tests, so although it doesn't use spring-boot-starter-test, it doesn't need org.junit.jupiter:junit-jupiter-engine either.
