### PR TITLE
chore(gha): replace action for creating github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,13 +117,13 @@ jobs:
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-${{ steps.build_variables.outputs.VERSION }}-unvalidated-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.event.repository.name }} ${{ github.ref }}
           body: |
             ${{ steps.release_info.outputs.CHANGELOG }}
           draft: false
+          name: ${{ github.event.repository.name }} ${{ github.ref }}
           prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
+          tag_name: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
actions/create-release@v1 is unmaintained (see https://github.com/actions/create-release) and generates warnings like
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
from e.g. https://github.com/spinnaker/rosco/actions/runs/4516827901/jobs/7955543641

https://github.com/softprops/action-gh-release seems like a good alterative (active git repo, lots of stars, users, etc.)
