### PR TITLE
fix(gha): remove refs/tags from github release names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           body: |
             ${{ steps.release_info.outputs.CHANGELOG }}
           draft: false
-          name: ${{ github.event.repository.name }} ${{ github.ref }}
+          name: ${{ github.event.repository.name }} ${{ github.ref_name }}
           prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
           tag_name: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
see https://docs.github.com/en/actions/learn-github-actions/contexts#github-context for documentation of `github.ref` vs. `github.ref_name`
