### PR TITLE
refactor(manifests): use new methods in manifest exception handling

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -4,7 +4,6 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.rosco.services.ClouddriverService;
 import java.io.IOException;
 import java.io.InputStream;

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -50,10 +50,8 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
                 artifact, e.getMessage()),
             e);
       }
-    } catch (SpinnakerHttpException e) {
-      throw new SpinnakerHttpException(downloadFailureMessage(artifact, e), e);
     } catch (SpinnakerException e) {
-      throw new SpinnakerException(downloadFailureMessage(artifact, e), e);
+      throw e.newInstance(downloadFailureMessage(artifact, e));
     }
   }
 


### PR DESCRIPTION
Uses the newInstance method on the SpinnakerException to clean up some exception handling in ArtifactDownloaderImpl.

The newInstance changes come from https://github.com/spinnaker/kork/pull/1046
