### PR TITLE
refactor(deprecation): remove deprecated gradle constructs/features from rosco in order to upgrade gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,11 @@ plugins {
 
 allprojects {
   apply plugin: 'io.spinnaker.project'
+
+  // both Jar (e.g. sourceJar) and ProcessResources tasks inherit from AbstractCopyTask
+  tasks.withType(AbstractCopyTask).all {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 }
 
 subprojects {


### PR DESCRIPTION
While executing the build script with --warning-mode=fail received below error:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```
And the deprecated gradle features are:
```
> Task :rosco-web:processResources
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: "banner.txt". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths. Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated
```
Replaced the deprecated default duplicates strategy with explicit 'DuplicatesStrategy.INCLUDE'.