### PR TITLE
refactor(tests): convert junit4 based testcases to junit5 and clean up in rosco

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -17,7 +17,6 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
@@ -32,12 +32,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.Call;
 import retrofit2.Response;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactDownloaderImplTest {
   private final ClouddriverService clouddriverService = mock(ClouddriverService.class);
   private final Call mockCall = mock(Call.class);

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/BakeManifestEnvironmentTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/BakeManifestEnvironmentTest.java
@@ -23,10 +23,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class BakeManifestEnvironmentTest {
   @Test
   void rejectsInvalidPaths() throws IOException {

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestServiceTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestServiceTest.java
@@ -31,10 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class CloudFoundryBakeManifestServiceTest {
 
   private ArtifactDownloader artifactDownloader = mock(ArtifactDownloader.class);

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.rosco.manifests.helm;
 
 import static com.netflix.spinnaker.rosco.manifests.ManifestTestUtils.makeSpinnakerHttpException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -60,11 +60,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 
-@RunWith(JUnitPlatform.class)
 final class HelmTemplateUtilsTest {
 
   private ArtifactDownloader artifactDownloader;


### PR DESCRIPTION
Before refactor, total test cases executed were 275. 
After refactor, total test cases executed are 275.