### PR TITLE
feat(artifact): Introduces the expansion of artifact store references in parameters

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.rosco.manifests.helmfile;
 
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader;
@@ -28,6 +30,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -41,8 +44,10 @@ public class HelmfileTemplateUtils extends HelmBakeTemplateUtils<HelmfileBakeMan
 
   public HelmfileTemplateUtils(
       ArtifactDownloader artifactDownloader,
+      Optional<ArtifactStore> artifactStore,
+      ArtifactStoreConfigurationProperties artifactStoreConfig,
       RoscoHelmfileConfigurationProperties helmfileConfigurationProperties) {
-    super(artifactDownloader);
+    super(artifactDownloader, artifactStore, artifactStoreConfig.getHelm());
     this.helmfileConfigurationProperties = helmfileConfigurationProperties;
   }
 
@@ -105,10 +110,7 @@ public class HelmfileTemplateUtils extends HelmBakeTemplateUtils<HelmfileBakeMan
 
     Map<String, Object> overrides = request.getOverrides();
     if (!overrides.isEmpty()) {
-      List<String> overrideList = new ArrayList<>();
-      for (Map.Entry<String, Object> entry : overrides.entrySet()) {
-        overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
-      }
+      List<String> overrideList = buildOverrideList(overrides);
       command.add("--set");
       command.add(String.join(",", overrideList));
     }

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
@@ -47,6 +49,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -70,6 +75,12 @@ final class HelmTemplateUtilsTest {
 
   private HelmBakeManifestRequest bakeManifestRequest;
 
+  /**
+   * Configuration for the default values in the event artifact store had been
+   * turned off.
+   */
+  private ArtifactStoreConfigurationProperties artifactStoreConfig;
+
   @BeforeEach
   private void init(TestInfo testInfo) {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
@@ -77,7 +88,14 @@ final class HelmTemplateUtilsTest {
     artifactDownloader = mock(ArtifactDownloader.class);
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
-    helmTemplateUtils = new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+    artifactStoreConfig = new ArtifactStoreConfigurationProperties();
+    ArtifactStoreConfigurationProperties.HelmConfig helmConfig =
+        new ArtifactStoreConfigurationProperties.HelmConfig();
+    artifactStoreConfig.setHelm(helmConfig);
+    helmConfig.setExpandOverrides(false);
+    helmTemplateUtils =
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
     Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
 
     bakeManifestRequest = new HelmBakeManifestRequest();
@@ -154,7 +172,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     String output = helmTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -208,7 +227,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     String output = helmTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -223,7 +243,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -256,7 +277,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
 
@@ -296,7 +318,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
 
@@ -356,7 +379,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -381,7 +405,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -406,7 +431,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -424,6 +450,54 @@ final class HelmTemplateUtilsTest {
   }
 
   @ParameterizedTest
+  @MethodSource("ensureOverrides")
+  public void ensureOverridesGetEvaluated(
+      String reference,
+      Map<String, Object> overrides,
+      String expected,
+      Boolean artifactStoreNull,
+      Boolean expandOverrides) {
+    ArtifactStore artifactStore = null;
+    if (!artifactStoreNull) {
+      artifactStore = mock(ArtifactStore.class);
+      when(artifactStore.get(any())).thenReturn(Artifact.builder().reference(reference).build());
+    }
+    RoscoHelmConfigurationProperties helmConfigurationProperties =
+        new RoscoHelmConfigurationProperties();
+
+    // do not use the artifactStoreConfig field as we are trying to test various
+    // values of expandOverrides
+    ArtifactStoreConfigurationProperties artifactStoreConfiguration =
+        new ArtifactStoreConfigurationProperties();
+    ArtifactStoreConfigurationProperties.HelmConfig helmConfig =
+        new ArtifactStoreConfigurationProperties.HelmConfig();
+    helmConfig.setExpandOverrides(expandOverrides);
+    artifactStoreConfiguration.setHelm(helmConfig);
+
+    HelmTemplateUtils helmTemplateUtils =
+        new HelmTemplateUtils(
+            artifactDownloader,
+            Optional.ofNullable(artifactStore),
+            artifactStoreConfiguration,
+            helmConfigurationProperties);
+    HelmBakeManifestRequest request = new HelmBakeManifestRequest();
+    request.setOutputName("output_name");
+    request.setTemplateRenderer(BakeManifestRequest.TemplateRenderer.HELM3);
+    request.setOverrides(overrides);
+    BakeRecipe recipe =
+        helmTemplateUtils.buildCommand(request, List.of(), Path.of("template_path"));
+
+    assertThat(recipe.getCommand().contains(expected)).isTrue();
+  }
+
+  private static Stream<Arguments> ensureOverrides() {
+    return Stream.of(
+        Arguments.of("test", Map.of("foo", "ref://bar/baz"), "foo=test", false, true),
+        Arguments.of("test", Map.of("foo", "ref://bar/baz"), "foo=ref://bar/baz", false, false),
+        Arguments.of("test", Map.of("foo", "ref://bar/baz"), "foo=ref://bar/baz", true, false));
+  }
+
+  @ParameterizedTest
   @MethodSource("helmRendererArgsCRDs")
   public void buildBakeRecipeNotIncludingCRDs(
       boolean includeCRDs, BakeManifestRequest.TemplateRenderer templateRenderer)
@@ -432,7 +506,8 @@ final class HelmTemplateUtilsTest {
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
     HelmTemplateUtils helmTemplateUtils =
-        new HelmTemplateUtils(artifactDownloader, helmConfigurationProperties);
+        new HelmTemplateUtils(
+            artifactDownloader, Optional.empty(), artifactStoreConfig, helmConfigurationProperties);
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtilsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
@@ -49,6 +50,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -72,6 +74,8 @@ final class HelmfileTemplateUtilsTest {
 
   private HelmfileBakeManifestRequest bakeManifestRequest;
 
+  private ArtifactStoreConfigurationProperties artifactStoreConfig;
+
   @BeforeEach
   private void init(TestInfo testInfo) {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
@@ -79,8 +83,17 @@ final class HelmfileTemplateUtilsTest {
     artifactDownloader = mock(ArtifactDownloader.class);
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
+    artifactStoreConfig = new ArtifactStoreConfigurationProperties();
+    ArtifactStoreConfigurationProperties.HelmConfig helmConfig =
+        new ArtifactStoreConfigurationProperties.HelmConfig();
+    artifactStoreConfig.setHelm(helmConfig);
+    helmConfig.setExpandOverrides(false);
     helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
     Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
 
     bakeManifestRequest = new HelmfileBakeManifestRequest();
@@ -177,7 +190,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     String output = helmfileTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -231,7 +248,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     String output = helmfileTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -246,7 +267,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
 
@@ -280,7 +305,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -320,7 +349,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -459,7 +492,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -483,7 +520,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -502,7 +543,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -526,7 +571,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -545,7 +594,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -567,7 +620,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -586,7 +643,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -610,7 +671,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -629,7 +694,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -656,7 +725,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();


### PR DESCRIPTION
This commit updates the Helm util helpers that we have to include the
artifact store. This will allow us to inspect the raw strings and check
to see if we need to expand them.

Further, I opted to not utilize the deserializer this time, since this
problem seemed very specific to Helm. If that changes, we can always
just use the deserializer

Signed-off-by: benjamin-j-powell <bjp@apple.com>We prefer small, well tested pull requests.
