### PR TITLE
feat(artifact): Introduces the expansion of artifact store references in parameters 

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/HelmBakeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/HelmBakeTemplateUtils.java
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.rosco.manifests;
 
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
@@ -24,24 +27,29 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.Getter;
 
 public abstract class HelmBakeTemplateUtils<T extends BakeManifestRequest> {
   private static final String MANIFEST_SEPARATOR = "---\n";
   private static final Pattern REGEX_TESTS_MANIFESTS =
       Pattern.compile("# Source: .*/templates/tests/.*");
 
-  private final ArtifactDownloader artifactDownloader;
+  @Getter private final ArtifactDownloader artifactDownloader;
+  private final ArtifactStore artifactStore;
+  private final ArtifactStoreConfigurationProperties.HelmConfig helmConfig;
 
-  protected HelmBakeTemplateUtils(ArtifactDownloader artifactDownloader) {
+  protected HelmBakeTemplateUtils(
+      ArtifactDownloader artifactDownloader,
+      Optional<ArtifactStore> artifactStore,
+      ArtifactStoreConfigurationProperties.HelmConfig helmConfig) {
     this.artifactDownloader = artifactDownloader;
-  }
-
-  public ArtifactDownloader getArtifactDownloader() {
-    return artifactDownloader;
+    this.artifactStore = artifactStore.orElse(null);
+    this.helmConfig = helmConfig;
   }
 
   public abstract String fetchFailureMessage(String description, Exception e);
@@ -102,5 +110,35 @@ public abstract class HelmBakeTemplateUtils<T extends BakeManifestRequest> {
     }
 
     return helmTypeFilePath;
+  }
+
+  /**
+   * This is a helper method to build the appropriate overrides in the event that an
+   * ArtifactReferenceURI was passed in an override
+   */
+  protected List<String> buildOverrideList(Map<String, Object> overrides) {
+    return overrides.entrySet().stream()
+        .map(
+            entry ->
+                entry.getKey() + "=" + expandArtifactReferenceURIs(entry.getValue()).toString())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * In the event that we encounter and ArtifactReferenceURI, we want to pull down that artifact
+   * instead of using the raw URI as a value for helm.
+   */
+  private Object expandArtifactReferenceURIs(Object value) {
+    if (artifactStore == null || !(helmConfig.isExpandOverrides() && value instanceof String)) {
+      return value;
+    }
+
+    String ref = (String) value;
+    if (ArtifactReferenceURI.is(ref)) {
+      Artifact artifact = artifactStore.get(ArtifactReferenceURI.parse(ref));
+      return artifact.getReference();
+    }
+
+    return ref;
   }
 }

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/HelmBakeTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/HelmBakeTemplateUtils.java
@@ -133,6 +133,17 @@ public abstract class HelmBakeTemplateUtils<T extends BakeManifestRequest> {
       return value;
     }
 
+    // It is important to note, since we do not have an object, but just a
+    // String, we can only check if the format matches an artifact reference
+    // URI.
+    //
+    // This means if a user is explicitly trying to pass a string with the same
+    // format, it will attempt to retrieve it and fail. SpEL handles this
+    // similar problem by returning the raw expression back, but that allows
+    // for intentional SpEL expressions to silently fail, which is why this is
+    // not done. Rather than fixing this potential issue now, we can address
+    // it once someone has reported it, since matching this format seems
+    // unlikely, but possible.
     String ref = (String) value;
     if (ArtifactReferenceURI.is(ref)) {
       Artifact artifact = artifactStore.get(ArtifactReferenceURI.parse(ref));

--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.rosco.manifests.helmfile;
 
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe;
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader;
@@ -28,6 +30,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -41,8 +44,10 @@ public class HelmfileTemplateUtils extends HelmBakeTemplateUtils<HelmfileBakeMan
 
   public HelmfileTemplateUtils(
       ArtifactDownloader artifactDownloader,
+      Optional<ArtifactStore> artifactStore,
+      ArtifactStoreConfigurationProperties artifactStoreConfig,
       RoscoHelmfileConfigurationProperties helmfileConfigurationProperties) {
-    super(artifactDownloader);
+    super(artifactDownloader, artifactStore, artifactStoreConfig.getHelm());
     this.helmfileConfigurationProperties = helmfileConfigurationProperties;
   }
 
@@ -105,10 +110,7 @@ public class HelmfileTemplateUtils extends HelmBakeTemplateUtils<HelmfileBakeMan
 
     Map<String, Object> overrides = request.getOverrides();
     if (!overrides.isEmpty()) {
-      List<String> overrideList = new ArrayList<>();
-      for (Map.Entry<String, Object> entry : overrides.entrySet()) {
-        overrideList.add(entry.getKey() + "=" + entry.getValue().toString());
-      }
+      List<String> overrideList = buildOverrideList(overrides);
       command.add("--set");
       command.add(String.join(",", overrideList));
     }

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtilsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
@@ -49,6 +50,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -72,6 +74,8 @@ final class HelmfileTemplateUtilsTest {
 
   private HelmfileBakeManifestRequest bakeManifestRequest;
 
+  private ArtifactStoreConfigurationProperties artifactStoreConfig;
+
   @BeforeEach
   private void init(TestInfo testInfo) {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
@@ -79,8 +83,17 @@ final class HelmfileTemplateUtilsTest {
     artifactDownloader = mock(ArtifactDownloader.class);
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
+    artifactStoreConfig = new ArtifactStoreConfigurationProperties();
+    ArtifactStoreConfigurationProperties.HelmConfig helmConfig =
+        new ArtifactStoreConfigurationProperties.HelmConfig();
+    artifactStoreConfig.setHelm(helmConfig);
+    helmConfig.setExpandOverrides(false);
     helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
     Artifact chartArtifact = Artifact.builder().name("test-artifact").version("3").build();
 
     bakeManifestRequest = new HelmfileBakeManifestRequest();
@@ -177,7 +190,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     String output = helmfileTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -231,7 +248,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     String output = helmfileTemplateUtils.removeTestsDirectoryTemplates(inputManifests);
 
@@ -246,7 +267,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
     RoscoHelmConfigurationProperties helmConfigurationProperties =
         new RoscoHelmConfigurationProperties();
 
@@ -280,7 +305,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -320,7 +349,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -459,7 +492,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -483,7 +520,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -502,7 +543,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -526,7 +571,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -545,7 +594,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -567,7 +620,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -586,7 +643,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -610,7 +671,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();
@@ -629,7 +694,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
 
@@ -656,7 +725,11 @@ final class HelmfileTemplateUtilsTest {
     RoscoHelmfileConfigurationProperties helmfileConfigurationProperties =
         new RoscoHelmfileConfigurationProperties();
     HelmfileTemplateUtils helmfileTemplateUtils =
-        new HelmfileTemplateUtils(artifactDownloader, helmfileConfigurationProperties);
+        new HelmfileTemplateUtils(
+            artifactDownloader,
+            Optional.empty(),
+            artifactStoreConfig,
+            helmfileConfigurationProperties);
 
     HelmfileBakeManifestRequest request = new HelmfileBakeManifestRequest();
     Artifact artifact = Artifact.builder().build();


### PR DESCRIPTION
This commit updates the Helm util helpers that we have to include the
artifact store. This will allow us to inspect the raw strings and check
to see if we need to expand them.

Further, I opted to not utilize the deserializer this time, since this
problem seemed very specific to Helm. If that changes, we can always
just use the deserializer

Signed-off-by: benjamin-j-powell <bjp@apple.com>
