### PR TITLE
feat(aws): Upgrade packer and add SSM support (Amazon)

### DIFF
--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -8,7 +8,7 @@ ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure googlecompute"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -60,11 +60,11 @@ USER spinnaker
 
 # Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
 RUN for plugin in $PACKER_PLUGINS ; do \
-    if [ -f /run/secrets/github_token ]; then \
-        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
-    else \
-        packer plugins install "github.com/hashicorp/$plugin"; \
-    fi; \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
 done
 
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -8,7 +8,7 @@ ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure docker googlecompute"
+ARG PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -3,11 +3,12 @@ LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUSTOMIZE_VERSION=3.8.6
 ENV KUSTOMIZE4_VERSION=4.5.5
-ENV PACKER_VERSION=1.8.1
+ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
+ARG PLUGINS="amazon azure docker googlecompute"
 
 WORKDIR /packer
 
@@ -56,5 +57,15 @@ COPY rosco-web/config              /opt/rosco
 COPY halconfig/packer              /opt/rosco/config/packer
 RUN mkdir -p /opt/rosco/plugins && chown -R spinnaker:nogroup /opt/rosco/plugins
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+RUN for plugin in $PACKER_PLUGINS ; do \
+    if [ -f /run/secrets/github_token ]; then \
+        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+    else \
+        packer plugins install "github.com/hashicorp/$plugin"; \
+    fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]
 

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -7,7 +7,7 @@ ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 ARG TARGETARCH
-ARG PACKER_PLUGINS="amazon azure docker googlecompute"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -72,11 +72,11 @@ USER spinnaker
 
 # Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
 RUN for plugin in $PACKER_PLUGINS ; do \
-    if [ -f /run/secrets/github_token ]; then \
-        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
-    else \
-        packer plugins install "github.com/hashicorp/$plugin"; \
-    fi; \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
 done
 
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -3,10 +3,11 @@ LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUSTOMIZE_VERSION=3.8.6
 ENV KUSTOMIZE4_VERSION=4.5.5
-ENV PACKER_VERSION=1.8.1
+ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 ARG TARGETARCH
+ARG PACKER_PLUGINS="amazon azure docker googlecompute"
 
 WORKDIR /packer
 
@@ -48,10 +49,29 @@ RUN mkdir helmfile && \
   mv ./helmfile/helmfile /usr/local/bin/helmfile && \
   rm -rf ./helmfile
 
+# Install AWS CLI 2 and the session manager plugin
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws && \
+  curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
+  dpkg -i session-manager-plugin.deb && \
+  rm session-manager-plugin.deb
+
 RUN adduser --system --uid 10111 --group spinnaker
 COPY rosco-web/build/install/rosco /opt/rosco
 COPY rosco-web/config              /opt/rosco
 COPY halconfig/packer              /opt/rosco/config/packer
 RUN mkdir -p /opt/rosco/plugins && chown -R spinnaker:nogroup /opt/rosco/plugins
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+RUN for plugin in $PACKER_PLUGINS ; do \
+    if [ -f /run/secrets/github_token ]; then \
+        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+    else \
+        packer plugins install "github.com/hashicorp/$plugin"; \
+    fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -50,7 +50,11 @@ RUN mkdir helmfile && \
   rm -rf ./helmfile
 
 # Install AWS CLI 2 and the session manager plugin
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+  fi && \
   unzip awscliv2.zip && \
   ./aws/install && \
   rm -rf ./awscliv2.zip ./aws && \

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -51,14 +51,15 @@ RUN mkdir helmfile && \
 
 # Install AWS CLI 2 and the session manager plugin
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
   else \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
   fi && \
   unzip awscliv2.zip && \
   ./aws/install && \
   rm -rf ./awscliv2.zip ./aws && \
-  curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
   dpkg -i session-manager-plugin.deb && \
   rm session-manager-plugin.deb
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -8,7 +8,7 @@ ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure googlecompute"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -60,11 +60,11 @@ USER spinnaker
 
 # Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
 RUN for plugin in $PACKER_PLUGINS ; do \
-    if [ -f /run/secrets/github_token ]; then \
-        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
-    else \
-        packer plugins install "github.com/hashicorp/$plugin"; \
-    fi; \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
 done
 
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -8,7 +8,7 @@ ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure docker googlecompute"
+ARG PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -3,11 +3,12 @@ LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUSTOMIZE_VERSION=3.8.6
 ENV KUSTOMIZE4_VERSION=4.5.5
-ENV PACKER_VERSION=1.8.1
+ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 
 ARG TARGETARCH
+ARG PLUGINS="amazon azure docker googlecompute"
 
 WORKDIR /packer
 
@@ -56,5 +57,15 @@ COPY rosco-web/config              /opt/rosco
 COPY halconfig/packer              /opt/rosco/config/packer
 RUN mkdir -p /opt/rosco/plugins && chown -R spinnaker:nogroup /opt/rosco/plugins
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+RUN for plugin in $PACKER_PLUGINS ; do \
+    if [ -f /run/secrets/github_token ]; then \
+        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+    else \
+        packer plugins install "github.com/hashicorp/$plugin"; \
+    fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -72,11 +72,11 @@ USER spinnaker
 
 # Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
 RUN for plugin in $PACKER_PLUGINS ; do \
-    if [ -f /run/secrets/github_token ]; then \
-        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
-    else \
-        packer plugins install "github.com/hashicorp/$plugin"; \
-    fi; \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
 done
 
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure googlecompute"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -3,10 +3,11 @@ LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUSTOMIZE_VERSION=3.8.6
 ENV KUSTOMIZE4_VERSION=4.5.5
-ENV PACKER_VERSION=1.8.1
+ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 ARG TARGETARCH
+ARG PLUGINS="amazon azure docker googlecompute"
 
 WORKDIR /packer
 
@@ -48,10 +49,29 @@ RUN mkdir helmfile && \
   mv ./helmfile/helmfile /usr/local/bin/helmfile && \
   rm -rf ./helmfile
 
+# Install AWS CLI 2 and the session manager plugin
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws && \
+  curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
+  dpkg -i session-manager-plugin.deb && \
+  rm session-manager-plugin.deb
+
 RUN adduser --system --uid 10111 --group spinnaker
 COPY rosco-web/build/install/rosco /opt/rosco
 COPY rosco-web/config              /opt/rosco
 COPY halconfig/packer              /opt/rosco/config/packer
 RUN mkdir -p /opt/rosco/plugins && chown -R spinnaker:nogroup /opt/rosco/plugins
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+RUN for plugin in $PACKER_PLUGINS ; do \
+    if [ -f /run/secrets/github_token ]; then \
+        PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+    else \
+        packer plugins install "github.com/hashicorp/$plugin"; \
+    fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ ENV PACKER_VERSION=1.10.1
 ENV HELMFILE_VERSION=0.153.1
 
 ARG TARGETARCH
-ARG PLUGINS="amazon azure docker googlecompute"
+ARG PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -50,7 +50,11 @@ RUN mkdir helmfile && \
   rm -rf ./helmfile
 
 # Install AWS CLI 2 and the session manager plugin
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+  fi && \
   unzip awscliv2.zip && \
   ./aws/install && \
   rm -rf ./awscliv2.zip ./aws && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -51,14 +51,15 @@ RUN mkdir helmfile && \
 
 # Install AWS CLI 2 and the session manager plugin
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
   else \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
   fi && \
   unzip awscliv2.zip && \
   ./aws/install && \
   rm -rf ./awscliv2.zip ./aws && \
-  curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
   dpkg -i session-manager-plugin.deb && \
   rm session-manager-plugin.deb
 

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -16,6 +16,9 @@ if [ -z `getent passwd spinnaker` ]; then
   useradd --gid spinnaker spinnaker -m --home-dir /home/spinnaker
 fi
 
+# Get the PACKER_PLUGINS environment variable or set a default value
+PACKER_PLUGINS=${PACKER_PLUGINS:-"amazon azure docker googlecompute"}
+
 create_temp_dir() {
   TEMPDIR=$(mktemp -d /tmp/installrosco.XXXX)
   cd $TEMPDIR
@@ -27,13 +30,18 @@ remove_temp_dir() {
 }
 
 install_packer() {
-  PACKER_VERSION="1.8.1"
-  local packer_version=$(/usr/bin/packer --version)
+  PACKER_VERSION="1.10.1"
+  local packer_version="$(/usr/bin/packer --version)"
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then
     wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
     unzip -o "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/bin
   fi
+
+  # Install plugins as the "spinnaker" user
+  for plugin in $PACKER_PLUGINS; do
+    su - spinnaker -c "/usr/bin/packer plugins install \"github.com/hashicorp/$plugin\""
+  done
 }
 
 install_helm() {
@@ -51,9 +59,22 @@ install_helm3() {
   mv /usr/local/bin/helm /usr/local/bin/helm3
 }
 
+install_aws_cli2() {
+  # Install AWS CLI v2
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
+  ./aws/install
+  rm -rf awscliv2.zip ./aws
+  # Install the session-manager-plugin
+  curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+  dpkg -i session-manager-plugin.deb
+  rm session-manager-plugin.deb
+}
+
 create_temp_dir
 install_packer
 install_helm3
 install_helm
+install_aws_cli2
 remove_temp_dir
 install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/rosco

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -17,7 +17,7 @@ if [ -z `getent passwd spinnaker` ]; then
 fi
 
 # Get the PACKER_PLUGINS environment variable or set a default value
-PACKER_PLUGINS=${PACKER_PLUGINS:-"amazon azure docker googlecompute"}
+PACKER_PLUGINS=${PACKER_PLUGINS:-"amazon azure googlecompute"}
 
 create_temp_dir() {
   TEMPDIR=$(mktemp -d /tmp/installrosco.XXXX)

--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -40,7 +40,7 @@ install_packer() {
   local packer_status=$?
   if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then
     wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip
-    unzip -o "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/bin
+    unzip -o "packer_${PACKER_VERSION}_linux_${ARCH}.zip" -d /usr/bin
   fi
 
   # Install plugins as the "spinnaker" user


### PR DESCRIPTION
This PR upgrades Packer to version v1.10.1. All the previously default providers were [moved to plugins in v1.10][1], so we also need to manually install plugins. I've opted to install Amazon, Azure and Google plugins by default, but the list can be overridden by Docker build args (or an environment variable in the case of the deb package).

This PR also installs AWS CLI 2 and the Session Manager Plugin in the Ubuntu images and in the deb package. **I opted to not install it in the Alpine images**, as the session-manager-plugin is not officially supported, and you'd need to either copy the binary or compile it from source to get it to work. I'm very open to reconsider this.

After applying this PR, you can use [SSM instead of SSH][2] to connect to instances when baking using the `amazon-ebs` provider (or friends).

[1]: https://www.hashicorp.com/blog/announcing-the-removal-of-bundled-plugins-in-hashicorp-packer
[2]: https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#session-manager-plugin