### PR TITLE
centralize lombok dependencies in build.gradle and use enforcedPlatform with kork-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ subprojects {
 
       compileOnly "org.projectlombok:lombok"
 
-      annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
       testCompileOnly "org.projectlombok:lombok"
 
-      testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      testAnnotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
 
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,17 @@ subprojects {
     dependencies {
       implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
+      compileOnly "org.projectlombok:lombok"
+
       annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+      testCompileOnly "org.projectlombok:lombok"
+
       testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     }
 

--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -1,7 +1,4 @@
 dependencies {
-  compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-
   api "io.spinnaker.kork:kork-artifacts"
   api "io.spinnaker.kork:kork-plugins"
   api "org.codehaus.groovy:groovy"

--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -1,9 +1,6 @@
 dependencies {
   implementation project(":rosco-core")
 
-  compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "io.spinnaker.kork:kork-artifacts"
   implementation "io.spinnaker.kork:kork-exceptions"


### PR DESCRIPTION
Centralize lombok dependencies to remove duplication.  Also add a testCompileOnly dependency to make lombok available to test code and to follow https://projectlombok.org/setup/gradle.

Use enforcedPlatform with kork-bom since it really is supposed to determine what versions of dependencies to use.  This also matches what [clouddriver](https://github.com/spinnaker/clouddriver/blob/3f31190d40419218fd1d31ca78bb1661f1ef881a/build.gradle) does.

No differences in the output of:
```
alias gradle-all-deps='./gradlew --no-parallel --stacktrace dependencies $(./gradlew -q projects \
    | grep -Fe ---\ Project \
    | sed -Ee "s/^.+--- Project '"'([^']+)'/\1:dependencies/"'" | sort)'
```
