### PR TITLE
fix(core): remove circular reference from AWSBakeHandler and RoscoAWSConfiguration classes identified during upgrade to spring boot 2.6.x

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/AWSBakeHandler.groovy
@@ -53,7 +53,6 @@ public class AWSBakeHandler extends CloudProviderBakeHandler {
 
   ImageNameFactory imageNameFactory = new ImageNameFactory()
 
-  @Autowired
   RoscoAWSConfiguration.AWSBakeryDefaults awsBakeryDefaults
 
   @Autowired


### PR DESCRIPTION
While upgrading spring boot 2.6.15 and spring cloud 2021.0.8, encountered below errors during runtime as part of rosco deployment:
```
WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'AWSBakeHandler': Unsatisfied dependency expressed through field 'awsBakeryDefaults'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration': Unsatisfied dependency expressed through field 'awsBakeHandler'; nested exception is org.springframework.beans.factory.BeanCurrentlyInCreationException: Error creating bean with name 'AWSBakeHandler': Requested bean is currently in creation: Is there an unresolvable circular reference?
INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
INFO 1 --- [           main] ConditionEvaluationReportLoggingListener :

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
ERROR 1 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   :

***************************
APPLICATION FAILED TO START
***************************

Description:

The dependencies of some of the beans in the application context form a cycle:

┌─────┐
|  AWSBakeHandler (field private com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration$AWSBakeryDefaults com.netflix.spinnaker.rosco.providers.aws.AWSBakeHandler.awsBakeryDefaults)
↑     ↓
|  com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration (field private com.netflix.spinnaker.rosco.providers.aws.AWSBakeHandler com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration.awsBakeHandler)
└─────┘

Action:

Relying upon circular references is discouraged and they are prohibited by default. Update your application to remove the dependency cycle between beans. As a last resort, it may be possible to break the cycle automatically by setting spring.main.allow-circular-references to true.
```
In order to resolve the issue removed the autowiring of `RoscoAWSConfiguration.AWSBakeryDefaults` instance as it is a static class and initialized as bean, part of `RoscoAWSConfiguration` configuration class.
