### PR TITLE
test(core): add tests to verify the rosco startup with various cloud providers enabled

### DIFF
--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -17,4 +17,8 @@ dependencies {
   implementation "redis.clients:jedis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.objenesis:objenesis"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.springframework:spring-test"
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
+  testImplementation project(":rosco-web")
 }

--- a/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/aws/AWSStartupTest.java
+++ b/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/aws/AWSStartupTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.aws;
+
+import com.netflix.spinnaker.rosco.Main;
+import com.netflix.spinnaker.rosco.providers.aws.config.RoscoAWSConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "spring.application.name=rosco",
+      "aws.enabled=true",
+      "rosco.config-dir=/some/path",
+      "bakeAccount=xyz"
+    })
+public class AWSStartupTest {
+
+  @Autowired AWSBakeHandler awsBakeHandler;
+
+  @Autowired RoscoAWSConfiguration.AWSBakeryDefaults awsBakeryDefaults;
+
+  @Test
+  public void startupTest() {}
+}

--- a/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/azure/AzureStartupTest.java
+++ b/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/azure/AzureStartupTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.azure;
+
+import com.netflix.spinnaker.rosco.Main;
+import com.netflix.spinnaker.rosco.providers.azure.config.RoscoAzureConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "spring.application.name=rosco",
+      "azure.enabled=true",
+      "rosco.config-dir=/some/path"
+    })
+public class AzureStartupTest {
+
+  @Autowired AzureBakeHandler azureBakeHandler;
+
+  @Autowired RoscoAzureConfiguration.AzureBakeryDefaults azureBakeryDefaults;
+
+  @Autowired RoscoAzureConfiguration.AzureConfigurationProperties azureConfigurationProperties;
+
+  @Test
+  public void startupTest() {}
+}

--- a/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/docker/DockerStartupTest.java
+++ b/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/docker/DockerStartupTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.docker;
+
+import com.netflix.spinnaker.rosco.Main;
+import com.netflix.spinnaker.rosco.providers.docker.config.RoscoDockerConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "spring.application.name=rosco",
+      "docker.enabled=true",
+      "rosco.config-dir=/some/path"
+    })
+public class DockerStartupTest {
+
+  @Autowired DockerBakeHandler dockerBakeHandler;
+
+  @Autowired RoscoDockerConfiguration.DockerBakeryDefaults dockerBakeryDefaults;
+
+  @Test
+  public void startupTest() {}
+}

--- a/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/google/GCEStartupTest.java
+++ b/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/google/GCEStartupTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.google;
+
+import com.netflix.spinnaker.rosco.Main;
+import com.netflix.spinnaker.rosco.providers.google.config.RoscoGoogleConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "spring.application.name=rosco",
+      "google.enabled=true",
+      "rosco.config-dir=/some/path"
+    })
+public class GCEStartupTest {
+
+  @Autowired GCEBakeHandler gceBakeHandler;
+
+  @Autowired RoscoGoogleConfiguration.GCEBakeryDefaults gceBakeryDefaults;
+
+  @Autowired RoscoGoogleConfiguration.GoogleConfigurationProperties googleConfigurationProperties;
+
+  @Test
+  public void startupTest() {}
+}

--- a/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/oracle/OracleStartupTest.java
+++ b/rosco-core/src/test/java/com/netflix/spinnaker/rosco/providers/oracle/OracleStartupTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.rosco.providers.oracle;
+
+import com.netflix.spinnaker.rosco.Main;
+import com.netflix.spinnaker.rosco.providers.oracle.config.OracleBakeryDefaults;
+import com.netflix.spinnaker.rosco.providers.oracle.config.OracleConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "spring.application.name=rosco",
+      "oracle.enabled=true",
+      "rosco.config-dir=/some/path"
+    })
+public class OracleStartupTest {
+
+  @Autowired OCIBakeHandler ociBakeHandler;
+
+  @Autowired OracleBakeryDefaults oracleBakeryDefaults;
+
+  @Autowired OracleConfigurationProperties oracleConfigurationProperties;
+
+  @Test
+  public void startupTest() {}
+}


### PR DESCRIPTION
Adding tests for AWS, Azure, Docker, Google and Oracle cloud providers to verify the rosco startup with these providers enabled.