### PR TITLE
fix(install): Removed install_aws_cli2 function from Debian post installation script which installs a Debian package within a Debian package causing errors, as well as errors when an aws cli is already installed (#6945)

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -64,25 +64,9 @@ install_helm3() {
   mv /usr/local/bin/helm /usr/local/bin/helm3
 }
 
-install_aws_cli2() {
-  if [ "$ARCH" = "amd64" ]; then
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-  elif [ "$ARCH" = "arm64" ]; then
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
-    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-  fi
-  unzip awscliv2.zip
-  ./aws/install
-  rm -rf awscliv2.zip ./aws
-  dpkg -i session-manager-plugin.deb
-  rm session-manager-plugin.deb
-}
-
 create_temp_dir
 install_packer
 install_helm3
 install_helm
-install_aws_cli2
 remove_temp_dir
 install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/rosco


### PR DESCRIPTION
This is a fix for [#6945](https://github.com/spinnaker/spinnaker/issues/6945).

* The post installation script should not attempt to install Debian packages within a Debian package, because the dpg process is already locked by itself and results in errors.
* If a version of awscli is already installed, it also generates errors.

Therefore the entire function to install aws cli v2 has been removed, and version 2 of the aws cli can be installed manually if it is required.