### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/rosco-core/rosco-core.gradle
+++ b/rosco-core/rosco-core.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api "io.spinnaker.kork:kork-artifacts"
   api "io.spinnaker.kork:kork-plugins"
-  api "org.codehaus.groovy:groovy"
+  api "org.apache.groovy:groovy"
 
   implementation "com.netflix.frigga:frigga"
   implementation "io.spinnaker.kork:kork-jedis"
@@ -12,7 +12,7 @@ dependencies {
   implementation "com.squareup.retrofit2:retrofit"
   implementation "io.reactivex:rxjava"
   implementation "org.apache.commons:commons-exec"
-  implementation "org.codehaus.groovy:groovy"
+  implementation "org.apache.groovy:groovy"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "redis.clients:jedis"
   testImplementation "org.spockframework:spock-core"

--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy
@@ -37,8 +37,8 @@ import io.swagger.annotations.ApiModelProperty
 class BakeRequest {
 
   // A generated uuid which will identify the request and be used as the jobId when running the bake
-  @ApiModelProperty(value = "A generated UUID which will be used to identify the effective packer bake", readOnly = true)
-  final String request_id = UUID.randomUUID().toString()
+  @ApiModelProperty(value = "A generated UUID which will be used to identify the effective packer bake", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+  String request_id = UUID.randomUUID().toString()
   String user
   @ApiModelProperty("The package(s) to install, as a space-delimited string") @JsonProperty("package") @SerializedName("package")
   String package_name

--- a/rosco-web/rosco-web.gradle
+++ b/rosco-web/rosco-web.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.swagger:swagger-annotations"
 
-  implementation "org.codehaus.groovy:groovy"
+  implementation "org.apache.groovy:groovy"
   implementation "io.spinnaker.kork:kork-artifacts"
   implementation "io.spinnaker.kork:kork-config"
   implementation "org.springframework.boot:spring-boot-starter-web"


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions. While upgrading groovy 4.0.15, encounter below error during build process of rosco-core module:
```
startup failed:
/rosco/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/api/BakeRequest.groovy: -1: Access to java.lang.Object#request_id is forbidden @ line -1, column -1.
1 error

> Task :rosco-core:compileGroovy FAILED
```
In order to make `request_id` accessible, removed `final` access specifier and updated the deprecated `ApiModelProperty.readOnly()` method with `ApiModelProperty.AccessMode()` [method](https://docs.swagger.io/swagger-core/v1.5.X/apidocs/io/swagger/annotations/ApiModelProperty.html#readOnly()) in `BakeRequest.groovy`.