### PR TITLE
fix(install): fix packer version check in post install script.

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -38,7 +38,8 @@ install_packer() {
   PACKER_VERSION="1.10.1"
   local packer_version="$(/usr/bin/packer --version)"
   local packer_status=$?
-  if [ $packer_status -ne 0 ] || [ "$packer_version" != "$PACKER_VERSION" ]; then
+
+  if [ $packer_status -ne 0 ] || ! grep -q "$PACKER_VERSION" <<< "$packer_version" ; then
     wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip
     unzip -o "packer_${PACKER_VERSION}_linux_${ARCH}.zip" -d /usr/bin
   fi


### PR DESCRIPTION
This attempt to fix the packer version check , which on failing would trigger a new download even if the same packer version is correctly insatalled.

This is an issue where packer for the arch type does not exists ( 404 ), eg. vm, docker images etc.
```
--2024-11-12 07:45:06--  https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_linux_.zip
Resolving releases.hashicorp.com (releases.hashicorp.com)... 99.86.20.99, 99.86.20.59, 99.86.20.95, ...
Connecting to releases.hashicorp.com (releases.hashicorp.com)|99.86.20.99|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-11-12 07:45:07 ERROR 404: Not Found.
```
packer version output format
```
himanshu@ubuntu-vm:~$ /usr/bin/packer  --version
Packer v1.10.1

Your version of Packer is out of date! The latest version
is 1.11.2. You can update by downloading from www.packer.io/downloads
```