### PR TITLE
fix(install): Fixed packer version check for packer installation

### DIFF
--- a/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco-web/pkg_scripts/postInstall.sh
@@ -39,7 +39,7 @@ install_packer() {
   local packer_version="$(/usr/bin/packer --version)"
   local packer_status=$?
 
-  if [ $packer_status -ne 0 ] || ! grep -q "$PACKER_VERSION" <<< "$packer_version" ; then
+  if [ $packer_status -ne 0 ] || ! echo "$packer_version" | grep -q "$PACKER_VERSION"; then
     wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip
     unzip -o "packer_${PACKER_VERSION}_linux_${ARCH}.zip" -d /usr/bin
   fi


### PR DESCRIPTION
Fixes the following error during post installation of the Rosco debian package:
```
Unpacking spinnaker-rosco (1.22.0) over (1.21.0) ...
Setting up spinnaker-rosco (1.22.0) ...
/var/lib/dpkg/info/spinnaker-rosco.postinst: 53: Syntax error: redirection unexpected
dpkg: error processing package spinnaker-rosco (--configure):
```
