### PR TITLE
fix(gceBakeHandler): Updating Image name pattern to match googlecompute pre/post 1.1.2 plugin

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandler.groovy
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference
 @Component
 public class GCEBakeHandler extends CloudProviderBakeHandler {
 
-  private static final String IMAGE_NAME_TOKEN = "googlecompute: A disk image was created:"
+  private static final String IMAGE_NAME_TOKEN = "googlecompute: A disk image was created"
 
   private final resolvedBakeryDefaults = new AtomicReference<RoscoGoogleConfiguration.GCEBakeryDefaults>()
 

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -164,16 +164,21 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
         "Build 'googlecompute' finished.\n" +
         "\n" +
         "==> Builds finished. The artifacts of successful builds are:\n" +
-        "--> googlecompute: A disk image was created: kato-x12345678-trusty"
+        "--> googlecompute: ${packerLog}"
 
-      Bake bake = gceBakeHandler.scrapeCompletedBakeResults(REGION, "123", logsContent)
+      Bake bake = gceBakeHandler.scrapeCompletedBakeResults(REGION, bakeId, logsContent)
 
     then:
       with (bake) {
-        id == "123"
+        id == bakeId
         !ami
-        image_name == "kato-x12345678-trusty"
+        image_name == imageName
       }
+
+    where:
+      packerLog | bakeId | imageName
+      "A disk image was created: kato-x12345678-trusty" | "123" | "kato-x12345678-trusty"
+      "A disk image was created in the test-gcp project: kato-x12345678-trusty-changed" | "456" | "kato-x12345678-trusty-changed"
   }
 
   void 'scraping returns null for missing image name'() {


### PR DESCRIPTION
Fixes issue https://github.com/spinnaker/spinnaker/issues/6982