### PR TITLE
fix(core): prevent null outputContent

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocal.groovy
@@ -177,9 +177,7 @@ class JobExecutorLocal implements JobExecutor {
           bakeStatus.state = BakeStatus.State.RUNNING
         }
 
-        if (outputContent) {
-          bakeStatus.outputContent = outputContent
-        }
+        bakeStatus.outputContent = outputContent
 
         if (logsContent) {
           bakeStatus.logsContent = logsContent

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocalSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/jobs/local/JobExecutorLocalSpec.groovy
@@ -79,4 +79,29 @@ Final output
       true                | COMBINED_OUTPUT | COMBINED_OUTPUT
       false               | EXPECTED_OUTPUT | EXPECTED_LOGS
   }
+
+  void 'job executor handles empty output'() {
+      def jobRequest = new JobRequest(
+          tokenizedCommand: ["true"],
+          jobId: SOME_JOB_ID,
+          combineStdOutAndErr: false)
+
+      @Subject
+      def jobExecutorLocal = new JobExecutorLocal(
+          registry: new DefaultRegistry(),
+          timeoutMinutes: 1)
+
+    when:
+      def jobId = jobExecutorLocal.startJob(jobRequest)
+      // Give the script time to run + 100 ms fudge factor
+      sleep(3000)
+      def bakeStatus = jobExecutorLocal.updateJob(jobId)
+
+    then:
+      bakeStatus != null
+      bakeStatus.state == BakeStatus.State.COMPLETED
+      bakeStatus.result == BakeStatus.Result.SUCCESS
+      bakeStatus.outputContent == ""
+      bakeStatus.logsContent == "No output from command."
+  }
 }


### PR DESCRIPTION
in the BakeStatus that JobExecutorLocal.updateStatus returns.

Before this change, if the output of e.g. helm template is an empty string, the BakeStatus object that JobExecutorLocal.updateStatus returns is null, and HelmTemplateUtils.removeTestsDirectoryTemplates throws a NullPointerException.

HelmBakeManifestService.bake calls BakeManifestService.doBake which calls JobExecutorLocal.updateStatus, and then HelmBakeManifestService.bake calls HelmTemplateUtils.removeTestsDirectoryTemplates with the resulting String.

With this change, removeTestsDirectoryTemplates gets an empty string, and so the bake manifest endpoint (e.g. POST /api/v2/manifest/bake/helm) returns an empty Artifact.

Note that there's no Bake Manifest YAML link in bake manifest stages with empty bakes, but this still feels like progress.

As well, without a corresponding change to clouddriver (https://github.com/spinnaker/clouddriver/pull/6337) to handle a null KubernetesManifest, there's still a clouddriver crash in a deploy manifest that consumes the output of this bake, but again, progress.

FWIW this is effectively a followup to https://github.com/spinnaker/rosco/pull/362. That PR added outputContent and there's still only the one place in the code that uses it.  So, there aren't other behavior changes to consider.