### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,7 +11,7 @@ ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget unzip curl git openssh-client && \
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install openjdk-17-jre-headless wget unzip curl git openssh-client && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
   unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
   rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#12 117.3 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#12 117.4 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#12 117.8 Segmentation fault (core dumped)
#12 117.8 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#12 118.2 Segmentation fault (core dumped)
#12 118.2 dpkg: error processing package libc-bin (--configure):
#12 118.2  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/rosco/actions/runs/13294123937/job/37121788387?pr=1138

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834